### PR TITLE
Allow font upload button to appear whenever a custom font is not already in webonary

### DIFF
--- a/wordpress/wp-content/plugins/sil-dictionary-webonary/include/configuration.php
+++ b/wordpress/wp-content/plugins/sil-dictionary-webonary/include/configuration.php
@@ -766,8 +766,7 @@ function webonary_conf_widget($showTitle = false)
 							}
 							else
 							{
-								$arrSystemFonts = $fontClass->get_system_fonts();
-								if(in_array($userFont, $arrSystemFonts))
+								if(in_array($userFont, $fontClass->get_system_fonts()))
 								{
 									echo 'This is a system font that most computers already have installed.';
 								}
@@ -783,18 +782,17 @@ function webonary_conf_widget($showTitle = false)
 										echo 'Font not found in the repository. Please ask Webonary Support to add it.';
 									}
 									echo '</strong>';
-
-									if (is_super_admin()) {
-										?>
-										<input type="hidden" name="fontname[<?php echo $fontNr; ?>]" value="<?php echo $userFont; ?>">
-										<input class="button-webonary" type="submit" value="Upload" name="uploadButton[<?php echo $fontNr; ?>]">
-										<?php
-
-										$fontNr++;
-									}
 								}
 							}
 
+							if(is_super_admin() && !in_array($userFont, $fontClass->get_system_fonts()))
+							{
+							?>
+								<input type="hidden" name="fontname[<?php echo $fontNr; ?>]" value="<?php echo $userFont; ?>">
+								<input class="button-webonary" type="submit" value="Upload" name="uploadButton[<?php echo $fontNr; ?>]">
+								<?php
+								$fontNr++;
+							}							
 							echo "<p></p>";
 						}
 					}


### PR DESCRIPTION
During the last major refactoring of sil-dictionary-webonary, the block of code for displaying font upload button got moved under a wrong if condition, so that it appears only when a font is not linked in custom.css. Reverting to the logic before sil-dicitionary-webonary release 8.3.8