### PR TITLE
Allow Webonary to consume data from webonary-cloud-api (initial limited checkin)

### DIFF
--- a/wordpress/wp-content/plugins/sil-dictionary-webonary/include/browseview_func.php
+++ b/wordpress/wp-content/plugins/sil-dictionary-webonary/include/browseview_func.php
@@ -870,16 +870,8 @@ function vernacularalphabet_func( $atts )
 		{
 			$arrPosts = getVernacularEntries($chosenLetter, $languagecode, $pagenr);
 		}
-		  
-		if(!isset($_GET['totalEntries']))
-		{
-			$totalEntries = count($arrPosts);
-		}
-		else
-		{
-			$totalEntries = $_GET['totalEntries'];
-		}
 
+		$totalEntries = $_GET['totalEntries'] ?? count($arrPosts);
 
 		if(count($arrPosts) == 0)
 		{

--- a/wordpress/wp-content/plugins/sil-dictionary-webonary/include/browseview_func.php
+++ b/wordpress/wp-content/plugins/sil-dictionary-webonary/include/browseview_func.php
@@ -483,7 +483,6 @@ function getReversalEntries($letter = "", $page, $reversalLangcode = "", &$displ
 		}
 
 		$arrReversals = $wpdb->get_results($sql);
-
 		if(count($arrReversals) > 0)
 		{
 			$displayXHTML = false;
@@ -592,7 +591,17 @@ function reversalindex($display, $chosenLetter, $langcode, $reversalnr = "")
 	$pagenr = filter_input(INPUT_GET, 'pagenr', FILTER_VALIDATE_INT, array('options' => array('default' => 1)));
 
 	$displayXHTML = true;
-	$arrReversals = getReversalEntries($chosenLetter, $pagenr, $langcode, $displayXHTML, $reversalnr);
+
+	if( get_option('useCloudBackend') )
+	{
+		$dictionary = Webonary_Cloud::getBlogDictionaryCode();
+		$arrReversals = Webonary_Cloud::getEntriesAsReversals($dictionary, $langcode, $chosenLetter);
+	}
+	else
+	{
+		$arrReversals = getReversalEntries($chosenLetter, $pagenr, $langcode, $displayXHTML, $reversalnr);
+	} 
+
 	if($arrReversals == null)
 	{
 		$display .= "No reversal entries imported.";
@@ -851,13 +860,20 @@ function vernacularalphabet_func( $atts )
 
 		//$arrPosts = query_posts("s=a&letter=" . $chosenLetter . "&noletters=" . $noLetters . "&langcode=" . $languagecode . "&posts_per_page=" . $posts_per_page . "&paged=" . $_GET['pagenr'] . "&DisplaySubentriesAsMainEntries=" . $displaySubentriesAsMinorEntries);
 		$pagenr = filter_input(INPUT_GET, 'pagenr', FILTER_VALIDATE_INT, array('options' => array('default' => 1)));
-		$arrPosts = getVernacularEntries($chosenLetter, $languagecode, $pagenr);
 
+		if( get_option('useCloudBackend') )
+		{
+			$dictionary = Webonary_Cloud::getBlogDictionaryCode();
+			$arrPosts = Webonary_Cloud::getEntriesAsPosts(Webonary_Cloud::$doBrowseByLetter, $dictionary, $chosenLetter);
+		}
+		else
+		{
+			$arrPosts = getVernacularEntries($chosenLetter, $languagecode, $pagenr);
+		}
+		  
 		if(!isset($_GET['totalEntries']))
 		{
-			$sql = "SELECT FOUND_ROWS()";
-
-			$totalEntries = $wpdb->get_var($sql);
+			$totalEntries = count($arrPosts);
 		}
 		else
 		{
@@ -907,5 +923,4 @@ function vernacularalphabet_func( $atts )
 }
 
 add_shortcode( 'vernacularalphabet', 'vernacularalphabet_func' );
-
 ?>

--- a/wordpress/wp-content/plugins/sil-dictionary-webonary/include/configuration.php
+++ b/wordpress/wp-content/plugins/sil-dictionary-webonary/include/configuration.php
@@ -222,6 +222,18 @@ function save_configurations()
 		}
 		update_option("noSearch", $noSearchForm);
 
+		$useCloudBackend = isset($_POST['useCloudBackend']) ? '1' : '0';
+		if($useCloudBackend != get_option('useCloudBackend', '0'))
+		{
+			if (is_plugin_active('wp-super-cache/wp-cache.php'))
+			{
+				/** @noinspection PhpUndefinedFunctionInspection */
+				prune_super_cache(get_supercache_dir(), true);
+			}
+			
+			update_option('useCloudBackend', $useCloudBackend);			
+		} 
+		
 		echo "<br>" . _e('Settings saved');
 	}
 }
@@ -813,6 +825,9 @@ function webonary_conf_widget($showTitle = false)
 				</p>
 				<p>
 					Hide search form: <input name="noSearchForm" type="checkbox" value="1" <?php checked('1', get_option('noSearch')); ?> />
+				</p>
+				<p>
+					Use Cloud Backend: <input name="useCloudBackend" type="checkbox" value="1" <?php checked('1', get_option('useCloudBackend')); ?> />
 				</p>
 				<p>
 					<?php Webonary_Configuration::admin_section_end('superadmin', 'Save Changes'); ?>

--- a/wordpress/wp-content/plugins/sil-dictionary-webonary/include/configuration.php
+++ b/wordpress/wp-content/plugins/sil-dictionary-webonary/include/configuration.php
@@ -220,7 +220,7 @@ function save_configurations()
 			}
 
 		}
-		update_option("noSearch", $noSearchForm);	
+		update_option("noSearch", $noSearchForm);
 
 		$useCloudBackend = filter_input(
 			INPUT_POST, 

--- a/wordpress/wp-content/plugins/sil-dictionary-webonary/include/configuration.php
+++ b/wordpress/wp-content/plugins/sil-dictionary-webonary/include/configuration.php
@@ -220,17 +220,21 @@ function save_configurations()
 			}
 
 		}
-		update_option("noSearch", $noSearchForm);
+		update_option("noSearch", $noSearchForm);	
 
-		$useCloudBackend = isset($_POST['useCloudBackend']) ? '1' : '0';
-		if($useCloudBackend != get_option('useCloudBackend', '0'))
+		$useCloudBackend = filter_input(
+			INPUT_POST, 
+			'useCloudBackend', 
+			FILTER_SANITIZE_STRING, 
+			array('options' => array('default' => '')));
+
+		if($useCloudBackend != get_option('useCloudBackend', ''))
 		{
 			if (is_plugin_active('wp-super-cache/wp-cache.php'))
 			{
 				/** @noinspection PhpUndefinedFunctionInspection */
 				prune_super_cache(get_supercache_dir(), true);
 			}
-			
 			update_option('useCloudBackend', $useCloudBackend);			
 		} 
 		
@@ -827,7 +831,7 @@ function webonary_conf_widget($showTitle = false)
 					Hide search form: <input name="noSearchForm" type="checkbox" value="1" <?php checked('1', get_option('noSearch')); ?> />
 				</p>
 				<p>
-					Use Cloud Backend: <input name="useCloudBackend" type="checkbox" value="1" <?php checked('1', get_option('useCloudBackend')); ?> />
+					Use cloud backend: <input name="useCloudBackend" type="checkbox" value="1" <?php checked('1', get_option('useCloudBackend')); ?> />
 				</p>
 				<p>
 					<?php Webonary_Configuration::admin_section_end('superadmin', 'Save Changes'); ?>

--- a/wordpress/wp-content/plugins/sil-dictionary-webonary/sil-dictionary.php
+++ b/wordpress/wp-content/plugins/sil-dictionary-webonary/sil-dictionary.php
@@ -82,6 +82,11 @@ add_action('preprocess_comment' , 'preprocess_comment_add_type');
 // API for FLEx
 add_action('rest_api_init', 'Webonary_API_MyType::Register_New_Routes');
 
+if (get_option('useCloudBackend')) {
+	add_filter('posts_pre_query', 'Webonary_Cloud::searchEntries', 10, 2);
+	// add_filter('the_content', 'Webonary_Cloud::getEntryAsPost');  
+}
+
 function add_rewrite_rules($aRules)
 {
 	//echo "rewrite rules<br>";

--- a/wordpress/wp-content/plugins/sil-dictionary-webonary/webonary/Webonary_Cloud.php
+++ b/wordpress/wp-content/plugins/sil-dictionary-webonary/webonary/Webonary_Cloud.php
@@ -1,0 +1,190 @@
+<?php
+
+
+class Webonary_Cloud
+{
+	public static $doBrowseByLetter = 'browse';
+
+	public static $doGetEntry = 'get';
+
+	public static $doSearchFulltext = 'search';
+
+	public static function entryToFakePost($dictionary, $entry) {	
+		//<div class="entry" id="ge5175994-067d-44c4-addc-ca183ce782a6"><span class="mainheadword"><span lang="es"><a href="http://localhost:8000/test/ge5175994-067d-44c4-addc-ca183ce782a6">bacalaitos</a></span></span><span class="senses"><span class="sensecontent"><span class="sense" entryguid="ge5175994-067d-44c4-addc-ca183ce782a6"><span class="definitionorgloss"><span lang="en">cod fish fritters/cod croquettes</span></span><span class="semanticdomains"><span class="semanticdomain"><span class="abbreviation"><span class=""><a href="http://localhost:8000/test/?s=&amp;partialsearch=1&amp;tax=9909">1.7</a></span></span><span class="name"><span class=""><a href="http://localhost:8000/test/?s=&amp;partialsearch=1&amp;tax=9909">Puerto Rican Fritters</a></span></span></span></span></span></span></span></div></div>
+		$mainHeadWord = '<span class="mainheadword"><span lang="' . $entry->mainHeadWord[0]->lang . '">'
+			. '<a href="' . get_site_url() . '/' . $entry->_id . '">' . $entry->mainHeadWord[0]->value . '</a></span></span>';
+	
+		$lexemeform = '';
+		if ($entry->audio->src != '') {
+			$lexemeform .= '<span class="lexemeform"><span><audio id="' . $entry->audio->id . '">';
+			$lexemeform .= '<source src="' . WEBONARY_CLOUD_FILE_PATH . $dictionary . '/'  . $entry->audio->src . '"></audio>';
+			$lexemeform .= '<a class="' . $entry->audio->fileClass . '" href="#' . $entry->audio->id . '" onClick="document.getElementById(\'' . $entry->audio->id .   '\').play()"> </a></span></span>';
+		}
+	
+		$sharedgrammaticalinfo = '<span class="sharedgrammaticalinfo"><span class="morphosyntaxanalysis"><span class="partofspeech"><span lang="' . $entry->senses->partOfSpeech->lang . '">' . $entry->senses->partOfSpeech->value . '</span></span></span></span>';
+	
+		$sensecontent = '<span class="sensecontent"><span class="sense" entryguid="' . $entry->_id . '">'
+			. '<span class="definitionorgloss">';
+		foreach( $entry->senses->definitionOrGloss as $definition )	{
+			$sensecontent .= '<span lang="' . $definition->lang . '">' . $definition->value . '</span>';
+		}
+		$sensecontent .= '</span></span>';
+	
+		$senses = '<span class="senses">' . $sharedgrammaticalinfo . $sensecontent . '</span>';
+	
+		$pictures = '';
+		if (count($entry->pictures)) {
+			$pictures = '<span class="pictures">';
+			foreach( $entry->pictures as $picture )	{
+				$pictures .= '<div class="picture">';
+				$pictures .= '<a class="image" href="' . WEBONARY_CLOUD_FILE_PATH . $dictionary . '/'  . $picture->src . '">';
+				$pictures .= '<img src="' . WEBONARY_CLOUD_FILE_PATH . $dictionary . '/'  . $picture->src . '"></a>';
+				$pictures .= '<div class="captioncontent"><span class="headword"><span lang="' . $definition->lang . '">' . $picture->caption . '</span></span></div>';
+				$pictures .= '</div>';
+			}
+			$pictures .= '</span>';	
+		}
+		$post = new stdClass();
+		$post->post_title = $entry->mainHeadWord[0]->value;
+		$post->post_name = $entry->_id;
+		$post->post_content = '<div class="entry" id="' . $entry->_id . '">' . $mainHeadWord . $lexemeform . $senses . $pictures . '</div>';
+		$post->post_status = 'publish';
+		$post->comment_status = 'closed';
+		$post->post_type = 'post';
+		$post->filter = 'raw'; // important, to prevent WP looking up this post in db!		
+	
+		return $post;
+	}
+
+	 public static function entryToReversal($dictionary, $lang, $letter, $entry) {	
+		//<div class=post><div xmlns="http://www.w3.org/1999/xhtml" class="reversalindexentry" id="g009ab666-43dd-4f2f-ba62-7017417f6b23"><span class="reversalform"><span lang="en">aardvark</span></span><span class="sensesrs"><span class="sensecontent"><span class="sensesr" entryguid="gee1142ec-65f5-4e23-8d95-413685a48c23"><span class="headword"><span lang="mos"><a href="https://www.webonary.org/moore/gee1142ec-65f5-4e23-8d95-413685a48c23">tãnturi</a></span></span><span class="scientificname"><span lang="en">orycteropus afer</span></span></span></span></span></div></div>
+		
+		$reversal_value = '';
+		foreach( $entry->senses->definitionOrGloss as $definition )	{
+			if( ($lang == $definition->lang) && ($letter == substr($definition->value, 0, 1)) ) {
+				$reversal_value = $definition->value;
+				break;
+			}
+		}
+	
+		$content = '<div class="reversalindexentry">';
+		$content .= '<span class="reversalform"><span lang="' . $lang . '">';
+		$content .= $reversal_value . '</span></span>';
+		
+		$content .= '<span class="sensesrs"><span class="sensecontent">';
+		$content .= '<span class="sensesr" entryguid="' . $entry->_id . '">';
+	
+		$content .= '<span class="headword"><span lang="' . $entry->mainHeadWord[0]->lang . '">'
+			. '<a href="' . get_site_url() . '/' . $entry->_id . '">' . $entry->mainHeadWord[0]->value . '</a></span></span>';
+	
+		$content .= '</span></span></span>';
+		$content .= '</<div>';
+		
+		$reversal = new stdClass();
+		$reversal->reversal_content = $content;
+	
+		return $reversal;
+	}
+
+	public static function getBlogDictionaryCode() {
+		return (
+			is_subdomain_install()
+			? explode('.', $_SERVER['HTTP_HOST'])[0]
+			: str_replace('/', '', get_blog_details()->path)
+		);
+	}
+
+	public static function getEntriesAsPosts($doAction, $dictionary, $text) {
+		$request = WEBONARY_CLOUD_ENTRY_PATH . $doAction . '/' . $dictionary;
+
+		switch ($doAction) {
+			case self::$doBrowseByLetter:
+				$request .= '?letterHead=' . $text;
+				break;
+			
+			case self::$doSearchFulltext:
+				$request .= '?fullText=' . $text;
+				break;
+			
+			default:
+				break;
+		}
+		
+		echo 'Getting results from ' . $request; 
+		$response = wp_remote_get($request);
+		$posts = [];
+	
+		if (is_array($response)) { 
+			$body = json_decode($response['body']); // use the content
+			foreach( $body as $key => $entry ) {
+				$post = self::entryToFakePost($dictionary, $entry);
+				$post->ID = -$key; // negative ID, to avoid clash with a valid post
+				$posts[$key] = $post;
+			}	
+		}
+	
+		return $posts;
+	}
+	
+	public static function getEntriesAsReversals($dictionary, $lang, $letter) {	
+		$request = WEBONARY_CLOUD_ENTRY_PATH
+			. self::$doBrowseByLetter . '/' 
+			. $dictionary . '?letterHead=' . $letter . '&lang=' . $lang;
+
+		// echo 'Getting results from ' . $request; 
+		$response = wp_remote_get($request);
+		$reversals = [];
+	
+		if (is_array($response)) { 
+			$body = json_decode($response['body']); // use the content
+			foreach( $body as $key => $entry ) {
+				$reversals[$key] = self::entryToReversal($dictionary, $lang, $letter, $entry);
+			}	
+		}
+	
+		return $reversals;
+	}
+
+	public static function getEntryAsPost($doAction, $dictionary, $page) {
+		$request = WEBONARY_CLOUD_ENTRY_PATH
+			. $doAction . '/' 
+			. $dictionary . '?guid=' . $page;
+		
+		echo 'Getting results from ' . $request; 
+		$response = wp_remote_get($request);
+	
+		if (is_array($response)) { 
+			$body = json_decode($response['body']); // use the content
+			$post = self::entryToFakePost($dictionary, $body);
+			$posts = [];
+			$key = 1;
+			$post->ID = -$key; // negative ID, to avoid clash with a valid post
+			$posts[$key] = $post;
+		}
+
+		return $posts;
+	}
+
+	public static function searchEntries($posts, WP_Query $query) {
+		if ($query->is_main_query()) {
+			$dictionary = Webonary_Cloud::getBlogDictionaryCode();
+
+			echo 'got dictionary ' . $dictionary;
+
+			$page = trim(get_query_var('pagename'));
+			echo 'got page ' . $page;
+
+			// Pagename begins with 'g', then followed by GUID
+			if (preg_match('/^g[a-f\d]{8}(-[a-f\d]{4}){4}[a-f\d]{8}$/i', $page)) {
+				return self::getEntryAsPost(self::$doGetEntry, $dictionary, $page);
+			}
+
+			$searchText = trim(get_search_query());
+			if ($searchText != '') {
+				return self::getEntriesAsPosts(self::$doSearchFulltext, $dictionary, $searchText);
+			}
+		}
+			
+		return null;
+	}	
+}

--- a/wordpress/wp-content/plugins/sil-dictionary-webonary/webonary/Webonary_Cloud.php
+++ b/wordpress/wp-content/plugins/sil-dictionary-webonary/webonary/Webonary_Cloud.php
@@ -204,14 +204,13 @@ class Webonary_Cloud
 		$request = $doAction . '/' . $dictionary;
 		$params = array('guid' => $id);
 		$response = self::remoteGet($request, $params);
-	
-		if (is_array($response)) { 
-			$body = json_decode($response['body']); // use the content
-			$post = self::entryToFakePost($dictionary, $body);
-			$posts = [];
-			$key = 1;
-			$post->ID = -$key; // negative ID, to avoid clash with a valid post
-			$posts[$key] = $post;
+		$entry = json_decode($response['body']); // use the content
+
+		$posts = [];
+		if (self::isValidEntry($entry)) { 
+			$post = self::entryToFakePost($dictionary, $entry);
+			$post->ID = -1; // negative ID, to avoid clash with a valid post
+			$posts[0] = $post;	
 		}
 
 		return $posts;
@@ -221,11 +220,11 @@ class Webonary_Cloud
 		if ($query->is_main_query()) {
 			$dictionary = Webonary_Cloud::getBlogDictionaryCode();
 
-			$page = trim(get_query_var('pagename'));
+			$pageName = trim(get_query_var('name'));
 
-			// Pagename begins with 'g', then followed by GUID
-			if (preg_match('/^g[a-f\d]{8}(-[a-f\d]{4}){4}[a-f\d]{8}$/i', $page)) {
-				return self::getEntryAsPost(self::$doGetEntry, $dictionary, $page);
+			// name begins with 'g', then followed by GUID
+			if (preg_match('/^g[a-f\d]{8}(-[a-f\d]{4}){4}[a-f\d]{8}$/i', $pageName)) {
+				return self::getEntryAsPost(self::$doGetEntry, $dictionary, ltrim($pageName, 'g'));
 			}
 
 			$searchText = trim(get_search_query());
@@ -233,7 +232,7 @@ class Webonary_Cloud
 				return self::getEntriesAsPosts(self::$doSearchFulltext, $dictionary, $searchText);
 			}
 		}
-			
+
 		return null;
-	}	
+	}
 }

--- a/wordpress/wp-content/plugins/sil-dictionary-webonary/webonary/Webonary_Cloud.php
+++ b/wordpress/wp-content/plugins/sil-dictionary-webonary/webonary/Webonary_Cloud.php
@@ -1,6 +1,5 @@
 <?php
 
-
 class Webonary_Cloud
 {
 	public static $doBrowseByLetter = 'browse';
@@ -9,23 +8,63 @@ class Webonary_Cloud
 
 	public static $doSearchFulltext = 'search';
 
+	private static function isValidEntry($entry) {
+		return is_object($entry) && isset($entry->_id);
+	} 
+
+	private static function convertGuidToId($guid) {
+		return 'g' . $guid;
+	} 
+
+	private static function remoteGet($request, $args = array()) {
+		if (!defined('WEBONARY_CLOUD_API_URL'))  {
+			error_log('WEBONARY_CLOUD_API_URL is not set! Please do so in wp-config.php.');
+			return;
+		}
+
+		$url = WEBONARY_CLOUD_API_URL . $request;
+
+		if (WP_DEBUG){
+			error_log('Getting results from ' . $url);
+			if (count($args)) {
+				error_log('using ' . print_r($args, true));
+			} 
+		}
+
+		return wp_remote_get($url, $args);
+	}
+
+	private static function remoteFileUrl($filePath) {
+		if (defined('WEBONARY_CLOUD_FILE_URL')) {
+			$fileUrl = WEBONARY_CLOUD_FILE_URL;
+		}
+		else {
+			error_log('WEBONARY_CLOUD_FILE_URL is not set! Please do so in wp-config.php.');
+			$fileUrl = '';
+		}
+		return $fileUrl . $filePath; 
+	}
+
 	public static function entryToFakePost($dictionary, $entry) {	
 		//<div class="entry" id="ge5175994-067d-44c4-addc-ca183ce782a6"><span class="mainheadword"><span lang="es"><a href="http://localhost:8000/test/ge5175994-067d-44c4-addc-ca183ce782a6">bacalaitos</a></span></span><span class="senses"><span class="sensecontent"><span class="sense" entryguid="ge5175994-067d-44c4-addc-ca183ce782a6"><span class="definitionorgloss"><span lang="en">cod fish fritters/cod croquettes</span></span><span class="semanticdomains"><span class="semanticdomain"><span class="abbreviation"><span class=""><a href="http://localhost:8000/test/?s=&amp;partialsearch=1&amp;tax=9909">1.7</a></span></span><span class="name"><span class=""><a href="http://localhost:8000/test/?s=&amp;partialsearch=1&amp;tax=9909">Puerto Rican Fritters</a></span></span></span></span></span></span></span></div></div>
+		$id = self::convertGuidToId($entry->_id);
 		$mainHeadWord = '<span class="mainheadword"><span lang="' . $entry->mainHeadWord[0]->lang . '">'
-			. '<a href="' . get_site_url() . '/' . $entry->_id . '">' . $entry->mainHeadWord[0]->value . '</a></span></span>';
-	
+			. '<a href="' . get_site_url() . '/' . $id . '">' . $entry->mainHeadWord[0]->value . '</a></span></span>';
+				
 		$lexemeform = '';
 		if ($entry->audio->src != '') {
 			$lexemeform .= '<span class="lexemeform"><span><audio id="' . $entry->audio->id . '">';
-			$lexemeform .= '<source src="' . WEBONARY_CLOUD_FILE_PATH . $dictionary . '/'  . $entry->audio->src . '"></audio>';
+			$lexemeform .= '<source src="' . self::remoteFileUrl($dictionary . '/' . $entry->audio->src) . '"></audio>';
 			$lexemeform .= '<a class="' . $entry->audio->fileClass . '" href="#' . $entry->audio->id . '" onClick="document.getElementById(\'' . $entry->audio->id .   '\').play()"> </a></span></span>';
 		}
 	
+		// TODO: There can be multiple media files, e.g. Hayashi, one for lexemeform and another in pronunciations
+
 		$sharedgrammaticalinfo = '<span class="sharedgrammaticalinfo"><span class="morphosyntaxanalysis"><span class="partofspeech"><span lang="' . $entry->senses->partOfSpeech->lang . '">' . $entry->senses->partOfSpeech->value . '</span></span></span></span>';
 	
-		$sensecontent = '<span class="sensecontent"><span class="sense" entryguid="' . $entry->_id . '">'
+		$sensecontent = '<span class="sensecontent"><span class="sense" entryguid="' . $id . '">'
 			. '<span class="definitionorgloss">';
-		foreach( $entry->senses->definitionOrGloss as $definition )	{
+		foreach ($entry->senses->definitionOrGloss as $definition)	{
 			$sensecontent .= '<span lang="' . $definition->lang . '">' . $definition->value . '</span>';
 		}
 		$sensecontent .= '</span></span>';
@@ -35,10 +74,11 @@ class Webonary_Cloud
 		$pictures = '';
 		if (count($entry->pictures)) {
 			$pictures = '<span class="pictures">';
-			foreach( $entry->pictures as $picture )	{
+			foreach ($entry->pictures as $picture)	{
+				$pictureUrl = self::remoteFileUrl($dictionary . '/' . $picture->src);
 				$pictures .= '<div class="picture">';
-				$pictures .= '<a class="image" href="' . WEBONARY_CLOUD_FILE_PATH . $dictionary . '/'  . $picture->src . '">';
-				$pictures .= '<img src="' . WEBONARY_CLOUD_FILE_PATH . $dictionary . '/'  . $picture->src . '"></a>';
+				$pictures .= '<a class="image" href="' . $pictureUrl . '">';
+				$pictures .= '<img src="' . $pictureUrl . '"></a>';
 				$pictures .= '<div class="captioncontent"><span class="headword"><span lang="' . $definition->lang . '">' . $picture->caption . '</span></span></div>';
 				$pictures .= '</div>';
 			}
@@ -46,8 +86,8 @@ class Webonary_Cloud
 		}
 		$post = new stdClass();
 		$post->post_title = $entry->mainHeadWord[0]->value;
-		$post->post_name = $entry->_id;
-		$post->post_content = '<div class="entry" id="' . $entry->_id . '">' . $mainHeadWord . $lexemeform . $senses . $pictures . '</div>';
+		$post->post_name = $id;
+		$post->post_content = '<div class="entry" id="' . $id . '">' . $mainHeadWord . $lexemeform . $senses . $pictures . '</div>';
 		$post->post_status = 'publish';
 		$post->comment_status = 'closed';
 		$post->post_type = 'post';
@@ -58,10 +98,10 @@ class Webonary_Cloud
 
 	 public static function entryToReversal($dictionary, $lang, $letter, $entry) {	
 		//<div class=post><div xmlns="http://www.w3.org/1999/xhtml" class="reversalindexentry" id="g009ab666-43dd-4f2f-ba62-7017417f6b23"><span class="reversalform"><span lang="en">aardvark</span></span><span class="sensesrs"><span class="sensecontent"><span class="sensesr" entryguid="gee1142ec-65f5-4e23-8d95-413685a48c23"><span class="headword"><span lang="mos"><a href="https://www.webonary.org/moore/gee1142ec-65f5-4e23-8d95-413685a48c23">tãnturi</a></span></span><span class="scientificname"><span lang="en">orycteropus afer</span></span></span></span></span></div></div>
-		
+		$id = self::convertGuidToId($entry->_id);
 		$reversal_value = '';
-		foreach( $entry->senses->definitionOrGloss as $definition )	{
-			if( ($lang == $definition->lang) && ($letter == substr($definition->value, 0, 1)) ) {
+		foreach ($entry->senses->definitionOrGloss as $definition)	{
+			if (($lang == $definition->lang) && ($letter == substr($definition->value, 0, 1))) {
 				$reversal_value = $definition->value;
 				break;
 			}
@@ -72,10 +112,10 @@ class Webonary_Cloud
 		$content .= $reversal_value . '</span></span>';
 		
 		$content .= '<span class="sensesrs"><span class="sensecontent">';
-		$content .= '<span class="sensesr" entryguid="' . $entry->_id . '">';
+		$content .= '<span class="sensesr" entryguid="' . $id . '">';
 	
 		$content .= '<span class="headword"><span lang="' . $entry->mainHeadWord[0]->lang . '">'
-			. '<a href="' . get_site_url() . '/' . $entry->_id . '">' . $entry->mainHeadWord[0]->value . '</a></span></span>';
+			. '<a href="' . get_site_url() . '/' . $id . '">' . $entry->mainHeadWord[0]->value . '</a></span></span>';
 	
 		$content .= '</span></span></span>';
 		$content .= '</<div>';
@@ -95,7 +135,7 @@ class Webonary_Cloud
 	}
 
 	public static function getEntriesAsPosts($doAction, $dictionary, $text) {
-		$request = WEBONARY_CLOUD_ENTRY_PATH . $doAction . '/' . $dictionary;
+		$request = $doAction . '/' . $dictionary;
 
 		switch ($doAction) {
 			case self::$doBrowseByLetter:
@@ -109,36 +149,37 @@ class Webonary_Cloud
 			default:
 				break;
 		}
-		
-		echo 'Getting results from ' . $request; 
-		$response = wp_remote_get($request);
+
+		$response = self::remoteGet($request);
 		$posts = [];
 	
 		if (is_array($response)) { 
 			$body = json_decode($response['body']); // use the content
-			foreach( $body as $key => $entry ) {
-				$post = self::entryToFakePost($dictionary, $entry);
-				$post->ID = -$key; // negative ID, to avoid clash with a valid post
-				$posts[$key] = $post;
-			}	
+			foreach ($body as $key => $entry) {
+				if (self::isValidEntry($entry)) {
+					$post = self::entryToFakePost($dictionary, $entry);
+					$post->ID = -$key; // negative ID, to avoid clash with a valid post
+					$posts[$key] = $post;	
+				}
+			}		
 		}
 	
 		return $posts;
 	}
 	
 	public static function getEntriesAsReversals($dictionary, $lang, $letter) {	
-		$request = WEBONARY_CLOUD_ENTRY_PATH
-			. self::$doBrowseByLetter . '/' 
+		$request = self::$doBrowseByLetter . '/' 
 			. $dictionary . '?letterHead=' . $letter . '&lang=' . $lang;
-
-		// echo 'Getting results from ' . $request; 
-		$response = wp_remote_get($request);
+		
+		$response = self::remoteGet($request);
 		$reversals = [];
 	
 		if (is_array($response)) { 
 			$body = json_decode($response['body']); // use the content
-			foreach( $body as $key => $entry ) {
-				$reversals[$key] = self::entryToReversal($dictionary, $lang, $letter, $entry);
+			foreach ($body as $key => $entry) {
+				if (self::isValidEntry($entry)) {
+					$reversals[$key] = self::entryToReversal($dictionary, $lang, $letter, $entry);
+				}
 			}	
 		}
 	
@@ -146,12 +187,9 @@ class Webonary_Cloud
 	}
 
 	public static function getEntryAsPost($doAction, $dictionary, $page) {
-		$request = WEBONARY_CLOUD_ENTRY_PATH
-			. $doAction . '/' 
-			. $dictionary . '?guid=' . $page;
+		$request = $doAction . '/' . $dictionary . '?guid=' . $page;
 		
-		echo 'Getting results from ' . $request; 
-		$response = wp_remote_get($request);
+		$response = self::remoteGet($request);
 	
 		if (is_array($response)) { 
 			$body = json_decode($response['body']); // use the content
@@ -169,10 +207,7 @@ class Webonary_Cloud
 		if ($query->is_main_query()) {
 			$dictionary = Webonary_Cloud::getBlogDictionaryCode();
 
-			echo 'got dictionary ' . $dictionary;
-
 			$page = trim(get_query_var('pagename'));
-			echo 'got page ' . $page;
 
 			// Pagename begins with 'g', then followed by GUID
 			if (preg_match('/^g[a-f\d]{8}(-[a-f\d]{4}){4}[a-f\d]{8}$/i', $page)) {

--- a/wordpress/wp-content/plugins/sil-dictionary-webonary/webonary/Webonary_Info.php
+++ b/wordpress/wp-content/plugins/sil-dictionary-webonary/webonary/Webonary_Info.php
@@ -62,12 +62,7 @@ class Webonary_Info
 				$status .= 'Last import of configured xhtml was at ' . $counts->indexed_date . ' (GMT).<br>';
 				$status .= 'Download data sent from FLEx: ';
 
-				if( is_subdomain_install() )
-					$dictionary_site = explode('.', $_SERVER['HTTP_HOST'])[0];	
-				else 
-					$dictionary_site = str_replace('/', '', get_blog_details()->path);
-
-				$archiveFile = $dictionary_site. '.zip';
+				$archiveFile = Webonary_Cloud::getBlogDictionaryCode() . '.zip';
  
 				if(file_exists(WP_CONTENT_DIR . '/archives/' . $archiveFile))
 					$status .= '<a href="/wp-content/archives/' . $archiveFile . '">' . $archiveFile . '</a>';


### PR DESCRIPTION
This is an initial check in of the code required to integrate Webonary Cloud API with Webonary Wordpress site. This PR is based on the Proof of Concept, and highlights some of the major features we wanted to achieve in Webonary 2.0.

This PR will allow:
1. browsing dictionary entries, using entry and media file data from the cloud api
2. basic searching of words 
3. browsing automatically generated reversal entries (not custom reversal entries)

More work will be needed to full replicate the existing Webonary dictionary entries, including (possibly):
1. using css files from cloud api
2. viewing full custom reversal entries
3. paging in browse and search results
4. more type of searches by fields
5. browse alphabet letter heads 

For now, dictionary data is stored in the cloud api using a limited parser for existing zip files, which exposes only some of the main fields for dictionary data. Once FLex is enhanced to upload dictionary data to the cloud backend, all dictionary fields should be exposed via the api.

To enable using Webonary Cloud API, the fellowing settings must be added to the wp-config.file:
```
/* Webonary Cloud Backend */
define('WEBONARY_CLOUD_API_URL', 'https://cloud-api.hanat.work/v1/');
define('WEBONARY_CLOUD_FILE_URL', 'https://s3.us-east-2.amazonaws.com/cloud-storage.hanat.work/');
```
 Then super admins can enable this per dictionary by  checking "Use cloud backend" in the Webonary plugin setting for a dictionary:

![Screen Shot 2020-04-28 at 1 38 35 PM](https://user-images.githubusercontent.com/60716623/80528926-4ff9f800-895c-11ea-9bf1-095e69e5b86b.png)

Eventually, this decision can be automatically made with a setting stored per dictionary site.

For testing, you can compare the following sites on https://www.hanatwork with their equivalent on the live Webonary site:

Test:
https://www.hanat.work/moore/
https://www.hanat.work/spanish-englishfooddictionary

Live:
https://www.webonary.org/moore/
https://www.webonary.org/spanish-englishfooddictionary

Please note that this PR was not mean to exactly Live features in Test, but as a starting point to demonstrate the possibility of using Webonary Cloud API.  More to come... :-)

NOTE: Performance difference between Test and Live is mainly due to disabling of super cache in Test. To do a comparison, super cache must be turned off in Live (per dictionary site).