### PR TITLE
webonary changes to browse by semantic domains from api

### DIFF
--- a/wordpress/wp-content/plugins/sil-dictionary-webonary/include/browseview_func.php
+++ b/wordpress/wp-content/plugins/sil-dictionary-webonary/include/browseview_func.php
@@ -36,8 +36,7 @@ function categories_func( $atts )
 					$arrDomains[$domain->abbreviation] = array('slug' => str_replace('.', '-', $domain->abbreviation), 'name' => $domain->name);
 				}
 			}
-
-			array_multisort(array_keys($arrDomains), SORT_NATURAL, $arrDomains);
+			ksort($arrDomains, SORT_NATURAL);
 		}
 	}
 	else

--- a/wordpress/wp-content/plugins/sil-dictionary-webonary/include/browseview_func.php
+++ b/wordpress/wp-content/plugins/sil-dictionary-webonary/include/browseview_func.php
@@ -36,7 +36,7 @@ function categories_func( $atts )
 					$arrDomains[$domain->abbreviation] = array('slug' => str_replace('.', '-', $domain->abbreviation), 'name' => $domain->name);
 				}
 			}
-			
+
 			array_multisort(array_keys($arrDomains), SORT_NATURAL, $arrDomains);
 		}
 	}
@@ -172,6 +172,7 @@ function categories_func( $atts )
 			$apiParams = array(
 				'text' => $semdomain,
 				'lang' => $qTransLang,
+				'semDomAbbrev' => rtrim($semnumber, '.'),
 				'searchSemDoms' => '1'
 			);
 

--- a/wordpress/wp-content/plugins/sil-dictionary-webonary/include/browseview_func.php
+++ b/wordpress/wp-content/plugins/sil-dictionary-webonary/include/browseview_func.php
@@ -48,13 +48,13 @@ function categories_func( $atts )
 		wp_register_style('configured_stylesheet', $upload_dir['baseurl'] . '/imported-with-xhtml.css?time=' . date("U"));
 		wp_enqueue_style( 'configured_stylesheet');
 
-    	$sql = "SELECT " . $wpdb->prefix . "terms.name, slug " .
+		$sql = "SELECT " . $wpdb->prefix . "terms.name, slug " .
 		" FROM " . $wpdb->prefix . "terms " .
 		" INNER JOIN " . $wpdb->prefix . "term_taxonomy ON " . $wpdb->prefix . "term_taxonomy.term_id = " . $wpdb->prefix . "terms.term_id " .
 		" WHERE taxonomy = 'sil_semantic_domains'" .
 		" ORDER BY CAST(slug as SIGNED INTEGER) ASC, CAST(RPAD(REPLACE(REPLACE(slug, '-', ''), '10','99'), 5, '0') AS SIGNED INTEGER) ASC "; //this creates a numeric sort
 
-    	$arrDomains = $wpdb->get_results($sql, ARRAY_A);
+		$arrDomains = $wpdb->get_results($sql, ARRAY_A);
 	}
 ?>
 	<style>
@@ -70,86 +70,86 @@ function categories_func( $atts )
 			float: right;
 			margin-top: 20px;
 		}
-	</style>
-	<script src="<?php echo get_bloginfo('wpurl'); ?>/wp-content/plugins/sil-dictionary-webonary/js/ua.js" type="text/javascript"></script>
+		</style>
+		<script src="<?php echo get_bloginfo('wpurl'); ?>/wp-content/plugins/sil-dictionary-webonary/js/ua.js" type="text/javascript"></script>
 
-	<!-- Infrastructure code for the tree -->
-	<script src="<?php echo get_bloginfo('wpurl'); ?>/wp-content/plugins/sil-dictionary-webonary/js/ftiens4.js" type="text/javascript"></script>
+		<!-- Infrastructure code for the tree -->
+		<script src="<?php echo get_bloginfo('wpurl'); ?>/wp-content/plugins/sil-dictionary-webonary/js/ftiens4.js" type="text/javascript"></script>
 
-	<!-- Execution of the code that actually builds the specific tree.
-     The variable foldersTree creates its structure with calls to gFld, insFld, and insDoc -->
-    <?php
-    //if(get_option("useSemDomainNumbers") == 0 || 1 == 1)
-    /*
-    if(get_option("useSemDomainNumbers") == 0)
-    {
-    ?>
-		<script src="<?php echo get_bloginfo('wpurl'); ?>/wp-content/plugins/sil-dictionary-webonary/js/categoryNodes_<?php echo $qTransLang; ?>.js" type="text/javascript"></script>
-	<?php
-    }
-    else
-    {
-    	*/
+		<!-- Execution of the code that actually builds the specific tree.
+		The variable foldersTree creates its structure with calls to gFld, insFld, and insDoc -->
+		<?php
+		//if(get_option("useSemDomainNumbers") == 0 || 1 == 1)
+		/*
+		if(get_option("useSemDomainNumbers") == 0)
+		{
+		?>
+			<script src="<?php echo get_bloginfo('wpurl'); ?>/wp-content/plugins/sil-dictionary-webonary/js/categoryNodes_<?php echo $qTransLang; ?>.js" type="text/javascript"></script>
+		<?php
+		}
+		else
+		{
+		*/
 		require_once( dirname( __FILE__ ) . '/semdomains_func.php' );
 
 		//if no semantic domains were imported, use the default domains defined in default_domains.php
-    	if(count($arrDomains) == 0)
-    	{
-    		$d = 0;
-    		foreach ($defaultDomain as $key => $value)
+		if(count($arrDomains) == 0)
+		{
+			$d = 0;
+			foreach ($defaultDomain as $key => $value)
 			{
 				$arrDomains[$d]['slug'] = str_replace(".", "-", rtrim($key, "."));
 				$arrDomains[$d]['name'] = $value;
 				$d++;
 			}
-    	}
+		}
 
-    	//echo "<script language=\"JavaScript\">";
+		//echo "<script language=\"JavaScript\">";
 
-    	foreach($arrDomains as $domain)
-    	{
-    		//echo $domain['slug'] . " " . $domain['name'] . "\n";
+		foreach($arrDomains as $domain)
+		{
+			//echo $domain['slug'] . " " . $domain['name'] . "\n";
 
-    		$slug = $domain['slug'];
-    		$domainNumber = $domain['slug'];
+			$slug = $domain['slug'];
+			$domainNumber = $domain['slug'];
 
-    		$domainNumberAsInt = preg_replace('/-/', '', $domainNumber);
+			$domainNumberAsInt = preg_replace('/-/', '', $domainNumber);
 
-    		if(is_numeric($domainNumberAsInt))
-    		{
-	    		$currentSemDomain =  $slug . " " . $domain['name'];
+			if(is_numeric($domainNumberAsInt))
+			{
+				$currentSemDomain =  $slug . " " . $domain['name'];
 
-	    		$levelOfDomain = substr_count("$domainNumber","-") + 1;
+				$levelOfDomain = substr_count("$domainNumber","-") + 1;
 
-	    		printRootDomainIfNeeded($domainNumber);
+				printRootDomainIfNeeded($domainNumber);
 
-	    		buildTreeToSupportThisItem($domainNumber, $levelOfDomain);
+				buildTreeToSupportThisItem($domainNumber, $levelOfDomain);
 
-	    		$domainNumberModified = preg_replace('/-/', '.', $domainNumber) . '.';
+				$domainNumberModified = preg_replace('/-/', '.', $domainNumber) . '.';
 
-	    		$domainName = trim(substr($currentSemDomain, strlen($domainNumber), strlen($currentSemDomain)));
+				$domainName = trim(substr($currentSemDomain, strlen($domainNumber), strlen($currentSemDomain)));
 
-	    		if($qTransLang == "en")
-	    		{
-	    			if(isset($defaultDomain[$domainNumberModified]))
-	    			{
-	    				$domainName = $defaultDomain[$domainNumberModified];
-	    			}
-	    		}
-	    		else
-	    		{
-	    			$domainName = __($domainName, 'sil_dictionary');
-	    		}
-	    		$newString = "$domainNumberModified" . " " . $domainName;
-	    		outputSemDomAsJava($levelOfDomain, $newString);
-	    		$currentDigits = explode('-', $domainNumber);
-	    		setLastSemDom($currentDigits);
-    		}
+				if($qTransLang == "en")
+				{
+					if(isset($defaultDomain[$domainNumberModified]))
+					{
+						$domainName = $defaultDomain[$domainNumberModified];
+					}
+				}
+				else
+				{
+					$domainName = __($domainName, 'sil_dictionary');
+				}
+				$newString = "$domainNumberModified" . " " . $domainName;
+				outputSemDomAsJava($levelOfDomain, $newString);
+				$currentDigits = explode('-', $domainNumber);
+				setLastSemDom($currentDigits);
+			}
 
-    	}
+		}
 
-    	echo "</script>";
-    //}
+		echo "</script>";
+	//}
 	?>
 	<!-- Build the browser's objects and display default view of the tree. -->
 	<script language="JavaScript">
@@ -691,11 +691,11 @@ function reversalindex($display, $chosenLetter, $langcode, $reversalnr = "")
 				$background = "even";
 			}
 		}
-    	$count++;
-    	if($count == $postsPerPage)
-    	{
-    		break;
-    	}
+		$count++;
+		if($count == $postsPerPage)
+		{
+			break;
+		}
 	}
 
 	$display .=  "<div style=clear:both></div>";

--- a/wordpress/wp-content/plugins/sil-dictionary-webonary/include/searchform_func.php
+++ b/wordpress/wp-content/plugins/sil-dictionary-webonary/include/searchform_func.php
@@ -36,17 +36,20 @@ function webonary_searchform() {
 	{
 		$dictionaryId = Webonary_Cloud::getBlogDictionaryId();
 		$dictionary = Webonary_Cloud::getDictionary($dictionaryId);
+		$currentLanguage = Webonary_Cloud::getCurrentLanguage();
 		if(!is_null($dictionary))
 		{
 			// set up parts of speech dropdown
-			if(count($dictionary->mainLanguage->partsOfSpeech))
+			if(count($dictionary->partsOfSpeech))
 			{
 				$parts_of_speech_dropdown .= "<select  name='tax' id='tax' class='postform' >";
 				$parts_of_speech_dropdown .= "<option value=''>" . __('All Parts of Speech','sil_dictionary') . "</option>";
-				foreach($dictionary->mainLanguage->partsOfSpeech as $part)
+				foreach($dictionary->partsOfSpeech as $part)
 				{
-					$selected = ($part === $taxonomy) ? ' selected ' : '';
-					$parts_of_speech_dropdown .= "<option value=" . $part . $selected . ">" . $part . "</option>";
+					if ($part->language === $currentLanguage) {
+						$selected = ($part->abbreviation === $taxonomy) ? ' selected ' : '';
+						$parts_of_speech_dropdown .= "<option value=" . $part->abbreviation . $selected . ">" . $part->name . "</option>";	
+					}
 				}
 				$parts_of_speech_dropdown .= "</select>";
 			}
@@ -59,12 +62,12 @@ function webonary_searchform() {
 				$sem_term = strtolower($search_term);
 				foreach($dictionary->semanticDomains as $item)
 				{
-					if(strpos($item->searchValue, $sem_term) !== false)
+					if(strpos($item->nameInsensitive, $sem_term) !== false)
 					{ 
 						$sem_domain = new stdClass();
-						$sem_domain->term_id = $item->value;
-						$sem_domain->slug = str_replace('.', '-', $item->key);
-						$sem_domain->description = $item->value;
+						$sem_domain->term_id = $item->name;
+						$sem_domain->slug = str_replace('.', '-', $item->abbreviation);
+						$sem_domain->description = $item->name;
 						$sem_domains[] = $sem_domain;  	
 					}
 				}

--- a/wordpress/wp-content/plugins/sil-dictionary-webonary/webonary/Webonary_Cloud.php
+++ b/wordpress/wp-content/plugins/sil-dictionary-webonary/webonary/Webonary_Cloud.php
@@ -168,6 +168,13 @@ class Webonary_Cloud
 		);
 	}
 
+	public static function getCurrentLanguage() {
+		return (
+			function_exists('qtranxf_init_language')
+			? qtranxf_getLanguage()
+			: 'en'
+		);
+	}
 
 	public static function getDictionary($dictionaryId) {
 		$request = self::$doGetDictionary . '/' . $dictionaryId;
@@ -298,14 +305,24 @@ class Webonary_Cloud
 			}
 			$searchText = trim(get_search_query());
 			if ($searchText === '') {
-				$tax = filter_input(INPUT_GET, 'tax', FILTER_SANITIZE_STRING, array('options' => array('default' => '')));
-				if ($tax !== '') {
-					// This is a listing by semantic domains			
+				// TODO: "tax" is used in search form both for parts of speech and for semantic domains
+				// But in browse semantic domains page, the parameter that contains the sem dom text is "semdomain".
+				// We should unify this.
+				foreach (array('tax', 'semdomain') as $param) {
+					$searchText = filter_input(INPUT_GET, $param, FILTER_SANITIZE_STRING, array('options' => array('default' => '')));
+					if ($searchText !== '') {
+						break;
+					}
+				}
+
+				if ($searchText !== '') {
 					$apiParams = array(
-						'text' => $tax,
+						'text' => $searchText,
+						'lang' => self::getCurrentLanguage(),
 						'searchSemDoms' => '1'
 					);
-	
+
+					// This is a listing by semantic domains				
 					return self::getEntriesAsPosts(self::$doSearchEntry, $dictionaryId, $apiParams);					
 				}
 			} 

--- a/wordpress/wp-content/plugins/sil-dictionary-webonary/webonary/Webonary_Cloud.php
+++ b/wordpress/wp-content/plugins/sil-dictionary-webonary/webonary/Webonary_Cloud.php
@@ -86,12 +86,11 @@ class Webonary_Cloud
 		}
 	
 		// TODO: There can be multiple media files, e.g. Hayashi, one for lexemeform and another in pronunciations
-
-		$sharedgrammaticalinfo = '<span class="sharedgrammaticalinfo"><span class="morphosyntaxanalysis"><span class="partofspeech"><span lang="' . $entry->senses->partOfSpeech->lang . '">' . $entry->senses->partOfSpeech->value . '</span></span></span></span>';
+		$sharedgrammaticalinfo = '<span class="sharedgrammaticalinfo"><span class="morphosyntaxanalysis"><span class="partofspeech"><span lang="' . $entry->morphoSyntaxAnalysis->partOfSpeech[0]->lang . '">' . $entry->morphoSyntaxAnalysis->partOfSpeech[0]->value . '</span></span></span></span>';
 	
 		$sensecontent = '<span class="sensecontent"><span class="sense" entryguid="' . $id . '">'
 			. '<span class="definitionorgloss">';
-		foreach ($entry->senses->definitionOrGloss as $definition)	{
+		foreach ($entry->senses[0]->definitionOrGloss as $definition)	{
 			$sensecontent .= '<span lang="' . $definition->lang . '">' . $definition->value . '</span>';
 		}
 		$sensecontent .= '</span></span>';
@@ -305,24 +304,14 @@ class Webonary_Cloud
 			}
 			$searchText = trim(get_search_query());
 			if ($searchText === '') {
-				// TODO: "tax" is used in search form both for parts of speech and for semantic domains
-				// But in browse semantic domains page, the parameter that contains the sem dom text is "semdomain".
-				// We should unify this.
-				foreach (array('tax', 'semdomain') as $param) {
-					$searchText = filter_input(INPUT_GET, $param, FILTER_SANITIZE_STRING, array('options' => array('default' => '')));
-					if ($searchText !== '') {
-						break;
-					}
-				}
-
-				if ($searchText !== '') {
+				$tax = filter_input(INPUT_GET, 'tax', FILTER_SANITIZE_STRING, array('options' => array('default' => '')));
+				if ($tax !== '') {
+					// This is a listing by semantic domains			
 					$apiParams = array(
-						'text' => $searchText,
-						'lang' => self::getCurrentLanguage(),
+						'text' => $tax,
 						'searchSemDoms' => '1'
 					);
-
-					// This is a listing by semantic domains				
+	
 					return self::getEntriesAsPosts(self::$doSearchEntry, $dictionaryId, $apiParams);					
 				}
 			} 


### PR DESCRIPTION
These changes will allow browsing by semantic domains using cloud api data.
Also, changes were made to accommodate db structure changes in the cloud api.

Note: 
1. Paging is not working. See https://github.com/sillsdev/webonary/issues/51
2. Currently, displaying entries for a domain results in all the entries from subdomains from being listed as well. A request has been made with Webonary owner if this behavior should be changed to display only entries specifically categorized for the domain. This PR assumes this behavior for now.

