### PR TITLE
added delete api and refactored models

### DIFF
--- a/webonary-cloud-api/.eslintignore
+++ b/webonary-cloud-api/.eslintignore
@@ -1,2 +1,3 @@
 cdk.out/
 node_modules/
+*.d.ts

--- a/webonary-cloud-api/lambda/__tests__/methodAuthorize.test.ts
+++ b/webonary-cloud-api/lambda/__tests__/methodAuthorize.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import { CustomAuthorizerEvent, Context } from 'aws-lambda';
 import axios from 'axios';
-import lambdaHandler from '../postAuthorize';
+import lambdaHandler from '../methodAuthorize';
 
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
@@ -35,7 +35,7 @@ const context: Context = {
   succeed: () => undefined,
 };
 
-describe('postAuthorize', () => {
+describe('methodAuthorize', () => {
   test('successful auth', async (): Promise<void> => {
     mockedAxios.post.mockImplementation(() => Promise.resolve({ status: 200, data: '' }));
     await lambdaHandler(event, context, (error, result) => {

--- a/webonary-cloud-api/lambda/base.model.ts
+++ b/webonary-cloud-api/lambda/base.model.ts
@@ -1,0 +1,11 @@
+/* eslint-disable max-classes-per-file */
+export interface PostResult {
+  updatedAt: string;
+  updatedCount: number;
+  insertedCount: number;
+  insertedIds?: string[];
+}
+export interface DbFindParameters {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+}

--- a/webonary-cloud-api/lambda/browseEntries.ts
+++ b/webonary-cloud-api/lambda/browseEntries.ts
@@ -9,7 +9,8 @@ import {
   DB_COLLATION_STRENGTH_FOR_INSENSITIVITY,
   DB_COLLATION_LOCALES,
 } from './db';
-import { DbFindParameters, DbPaths, DictionaryEntry } from './structs';
+import { DbFindParameters } from './base.model';
+import { DictionaryEntry, DbPaths } from './entry.model';
 import { getDbSkip } from './utils';
 import * as Response from './response';
 
@@ -20,12 +21,9 @@ export async function handler(
   context: Context,
   callback: Callback,
 ): Promise<void> {
-  // eslint-disable-next-line no-param-reassign
-  context.callbackWaitsForEmptyEventLoop = false;
-
   try {
-    dbClient = await connectToDB();
-    const db = dbClient.db(DB_NAME);
+    // eslint-disable-next-line no-param-reassign
+    context.callbackWaitsForEmptyEventLoop = false;
 
     const dictionaryId = event.pathParameters?.dictionaryId;
     const text = event.queryStringParameters?.text;
@@ -57,6 +55,9 @@ export async function handler(
     let dbSortKey: string;
     let dbLocale = DB_COLLATION_LOCALE_DEFAULT_FOR_INSENSITIVITY;
     const dbSkip = getDbSkip(pageNumber, pageLimit);
+
+    dbClient = await connectToDB();
+    const db = dbClient.db(DB_NAME);
 
     if (lang) {
       // TODO: Include reversal language in sorting?
@@ -98,7 +99,7 @@ export async function handler(
       }
 
       // TODO: Make sure to set default sort for entries to be on main headword browse letter and value
-      dbSortKey = DbPaths.ENTRY_MAIN_HEADWORD_VALUE;
+      dbSortKey = DbPaths.ENTRY_MAIN_HEADWORD_FIRST_VALUE;
       if (mainLang && mainLang !== '' && DB_COLLATION_LOCALES.includes(mainLang)) {
         dbLocale = mainLang;
       }

--- a/webonary-cloud-api/lambda/deleteDictionary.ts
+++ b/webonary-cloud-api/lambda/deleteDictionary.ts
@@ -1,8 +1,7 @@
 import { APIGatewayEvent, Context, Callback } from 'aws-lambda';
-import { MongoClient } from 'mongodb';
+import { MongoClient, DeleteWriteOpResultObject } from 'mongodb';
 import { connectToDB } from './mongo';
 import { DB_NAME, DB_COLLECTION_DICTIONARIES, DB_COLLECTION_ENTRIES } from './db';
-import { Dictionary } from './dictionary.model';
 import * as Response from './response';
 
 let dbClient: MongoClient;
@@ -20,20 +19,32 @@ export async function handler(
 
     dbClient = await connectToDB();
     const db = dbClient.db(DB_NAME);
-    const dbItem: Dictionary | null = await db
-      .collection(DB_COLLECTION_DICTIONARIES)
-      .findOne({ _id: dictionaryId });
 
-    if (!dbItem) {
+    const count = await db
+      .collection(DB_COLLECTION_DICTIONARIES)
+      .countDocuments({ _id: dictionaryId });
+
+    if (!count) {
       return callback(null, Response.notFound({}));
     }
 
-    // get total entries
-    dbItem.mainLanguage.entriesCount = await db
-      .collection(DB_COLLECTION_ENTRIES)
-      .countDocuments({ dictionaryId });
+    const dbResultDictionary: DeleteWriteOpResultObject = await db
+      .collection(DB_COLLECTION_DICTIONARIES)
+      .deleteOne({ _id: dictionaryId });
 
-    return callback(null, Response.success(dbItem));
+    const dbResultEntry: DeleteWriteOpResultObject = await db
+      .collection(DB_COLLECTION_ENTRIES)
+      .deleteMany({ dictionaryId });
+
+    // TODO: How to delete S3 files in the dictionary folder???
+
+    return callback(
+      null,
+      Response.success({
+        deleteDictionaryCount: dbResultDictionary.deletedCount,
+        deletedEntryCount: dbResultEntry.deletedCount,
+      }),
+    );
   } catch (error) {
     // eslint-disable-next-line no-console
     console.log(error);

--- a/webonary-cloud-api/lambda/dictionary.model.ts
+++ b/webonary-cloud-api/lambda/dictionary.model.ts
@@ -1,0 +1,69 @@
+/* eslint-disable max-classes-per-file */
+export interface Language {
+  lang: string;
+  title: string;
+  letters: string[];
+  cssFiles?: string[];
+  entriesCount?: number;
+}
+
+export declare class LanguageItem implements Language {
+  lang: string;
+
+  title: string;
+
+  letters: string[];
+
+  cssFiles?: string[];
+}
+
+export interface ListOption {
+  lang: string;
+  abbreviation: string;
+  name: string;
+  nameInsensitive?: string; // lowercase and normalized
+  guid?: string;
+}
+
+export class ListOptionItem implements ListOption {
+  lang = '';
+
+  abbreviation = '';
+
+  name = '';
+
+  nameInsensitive? = '';
+
+  guid? = '';
+}
+
+export interface Dictionary {
+  _id: string;
+  updatedAt: string;
+  mainLanguage: Language;
+  reversalLanguages: Language[];
+  partsOfSpeech?: ListOption[];
+  semanticDomains?: ListOption[];
+}
+export declare class DictionaryItem implements Dictionary {
+  _id: string;
+
+  updatedAt: string;
+
+  mainLanguage: LanguageItem;
+
+  reversalLanguages: LanguageItem[];
+
+  partsOfSpeech?: ListOptionItem[];
+
+  semanticDomains?: ListOptionItem[];
+
+  constructor(dictionaryId: string, updatedAt?: string);
+}
+
+export declare enum DbPaths {
+  SEM_DOMS_LANG = 'semanticDomains.lang',
+  SEM_DOMS_ABBREV = 'semanticDomains.abbrev',
+  SEM_DOMS_VALUE = 'semanticDomains.value',
+  SEM_DOMS_VALUE_INSENSITIVE = 'semanticDomains.valueInsensitive',
+}

--- a/webonary-cloud-api/lambda/dictionary.model.ts
+++ b/webonary-cloud-api/lambda/dictionary.model.ts
@@ -7,14 +7,14 @@ export interface Language {
   entriesCount?: number;
 }
 
-export declare class LanguageItem implements Language {
-  lang: string;
+export class LanguageItem implements Language {
+  lang = '';
 
-  title: string;
+  title = '';
 
-  letters: string[];
+  letters: string[] = [];
 
-  cssFiles?: string[];
+  cssFiles?: string[] = [];
 }
 
 export interface ListOption {
@@ -45,7 +45,8 @@ export interface Dictionary {
   partsOfSpeech?: ListOption[];
   semanticDomains?: ListOption[];
 }
-export declare class DictionaryItem implements Dictionary {
+
+export class DictionaryItem implements Dictionary {
   _id: string;
 
   updatedAt: string;
@@ -58,10 +59,19 @@ export declare class DictionaryItem implements Dictionary {
 
   semanticDomains?: ListOptionItem[];
 
-  constructor(dictionaryId: string, updatedAt?: string);
+  constructor(dictionaryId: string, updatedAt?: string) {
+    this._id = dictionaryId;
+    this.updatedAt = updatedAt ?? new Date().toUTCString();
+
+    // Set initial values so we can do Object.keys for dynamic case-insensitive copying
+    this.mainLanguage = new LanguageItem();
+    this.reversalLanguages = Array(new LanguageItem());
+    this.partsOfSpeech = Array(new ListOptionItem());
+    this.semanticDomains = Array(new ListOptionItem());
+  }
 }
 
-export declare enum DbPaths {
+export enum DbPaths {
   SEM_DOMS_LANG = 'semanticDomains.lang',
   SEM_DOMS_ABBREV = 'semanticDomains.abbrev',
   SEM_DOMS_VALUE = 'semanticDomains.value',

--- a/webonary-cloud-api/lambda/entry.model.ts
+++ b/webonary-cloud-api/lambda/entry.model.ts
@@ -16,26 +16,6 @@ export class EntryFileItem implements EntryFile {
   caption? = '';
 }
 
-export interface EntryListOption {
-  lang: string;
-  abbreviation: string;
-  name: string;
-  nameInsensitive?: string; // lowercase and normalized
-  guid?: string;
-}
-
-export class EntryListOptionItem implements EntryListOption {
-  lang = '';
-
-  abbreviation = '';
-
-  name = '';
-
-  nameInsensitive? = '';
-
-  guid? = '';
-}
-
 export interface EntryValue {
   lang: string;
   value: string;
@@ -154,70 +134,10 @@ export class DictionaryEntryItem implements DictionaryEntry {
   }
 }
 
-export interface Language {
-  lang: string;
-  title: string;
-  letters: string[];
-  cssFiles?: string[];
-  entriesCount?: number;
-}
-
-export class LanguageItem implements Language {
-  lang = '';
-
-  title = '';
-
-  letters: string[] = [];
-
-  cssFiles?: string[] = [];
-}
-
-export interface Dictionary {
-  _id: string;
-  updatedAt: string;
-  mainLanguage: Language;
-  reversalLanguages: Language[];
-  partsOfSpeech?: EntryListOption[];
-  semanticDomains?: EntryListOption[];
-}
-
-export class DictionaryItem implements Dictionary {
-  _id: string;
-
-  updatedAt: string;
-
-  mainLanguage: LanguageItem;
-
-  reversalLanguages: LanguageItem[];
-
-  partsOfSpeech?: EntryListOptionItem[];
-
-  semanticDomains?: EntryListOptionItem[];
-
-  constructor(dictionaryId: string, updatedAt?: string) {
-    this._id = dictionaryId;
-    this.updatedAt = updatedAt ?? new Date().toUTCString();
-
-    // Set initial values so we can do Object.keys for dynamic case-insensitive copying
-    this.mainLanguage = new LanguageItem();
-    this.reversalLanguages = Array(new LanguageItem());
-    this.partsOfSpeech = Array(new EntryListOptionItem());
-    this.semanticDomains = Array(new EntryListOptionItem());
-  }
-}
-
-export interface DbFindParameters {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: any;
-}
-
 export enum DbPaths {
-  SEM_DOMS_LANG = 'semanticDomains.lang',
-  SEM_DOMS_ABBREV = 'semanticDomains.abbrev',
-  SEM_DOMS_VALUE = 'semanticDomains.value',
-  SEM_DOMS_VALUE_INSENSITIVE = 'semanticDomains.valueInsensitive',
   ENTRY_MAIN_HEADWORD_LANG = 'mainHeadWord.lang',
   ENTRY_MAIN_HEADWORD_VALUE = 'mainHeadWord.value',
+  ENTRY_MAIN_HEADWORD_FIRST_VALUE = 'mainHeadWord.0.value',
   ENTRY_SENSES = 'senses',
   ENTRY_DEFINITION = 'senses.definitionOrGloss',
   ENTRY_DEFINITION_LANG = 'senses.definitionOrGloss.lang',

--- a/webonary-cloud-api/lambda/getEntry.ts
+++ b/webonary-cloud-api/lambda/getEntry.ts
@@ -16,6 +16,11 @@ export async function handler(
 
   const dictionaryId = event.pathParameters?.dictionaryId;
   const _id = event.queryStringParameters?.guid;
+
+  if (!_id || _id === '') {
+    return callback(null, Response.badRequest('guid for the dictionary entry must be specified.'));
+  }
+
   try {
     dbClient = await connectToDB();
     const db = dbClient.db(DB_NAME);

--- a/webonary-cloud-api/lambda/methodAuthorize.ts
+++ b/webonary-cloud-api/lambda/methodAuthorize.ts
@@ -37,28 +37,28 @@ export async function handler(
   const authHeaders = event.headers?.Authorization;
 
   if (dictionaryId && authHeaders) {
-    const encodedCredentials = authHeaders.split(' ')[1];
-    const plainCredentials = Buffer.from(encodedCredentials, 'base64')
-      .toString()
-      .split(':');
-    const username = plainCredentials[0];
-    const password = plainCredentials[1];
-
-    // Same user should have the same access to post dictionary entry data as well as files.
-    // User access is per dictionary per user.
-    const principalId = `${dictionaryId}::${username}`;
-
-    // To allow for correct caching behavior, we only keep the first part of request (post) and use wildcard for the next
-    const resource = event.methodArn.replace(
-      /POST\/post\/(dictionary|entry|file)\//i,
-      'POST/post/*/',
-    );
-
-    // Call Webonary.org for user authentication
-    axios.defaults.headers.post['Content-Type'] = 'application/json';
-    const authPath = `${process.env.WEBONARY_URL}/${dictionaryId}${process.env.WEBONARY_AUTH_PATH}`;
-
     try {
+      const encodedCredentials = authHeaders.split(' ')[1];
+      const plainCredentials = Buffer.from(encodedCredentials, 'base64')
+        .toString()
+        .split(':');
+      const username = plainCredentials[0];
+      const password = plainCredentials[1];
+
+      // Same user should have the same access to post dictionary entry data as well as files.
+      // User access is per dictionary per user.
+      const principalId = `${dictionaryId}::${username}`;
+
+      // To allow for correct caching behavior, we only keep the first part of request (post) and use wildcard for the next
+      const resource = event.methodArn.replace(
+        /(POST\/post|DELETE\/delete)\/(dictionary|entry|file)\//i,
+        '$1/*/',
+      );
+
+      // Call Webonary.org for user authentication
+      axios.defaults.headers.post['Content-Type'] = 'application/json';
+      const authPath = `${process.env.WEBONARY_URL}/${dictionaryId}${process.env.WEBONARY_AUTH_PATH}`;
+
       const response = await axios.post(authPath, '{}', {
         auth: { username, password },
       });

--- a/webonary-cloud-api/lambda/postDictionary.ts
+++ b/webonary-cloud-api/lambda/postDictionary.ts
@@ -113,15 +113,11 @@ import {
   DB_COLLATION_LOCALE_DEFAULT_FOR_INSENSITIVITY,
   DB_COLLATION_STRENGTH_FOR_INSENSITIVITY,
 } from './db';
-import { DbPaths, DictionaryItem } from './structs';
+import { PostResult } from './base.model';
+import { DictionaryItem } from './dictionary.model';
+import { DbPaths } from './entry.model';
 import { copyObjectIgnoreKeyCase, setSearchableEntries } from './utils';
 import * as Response from './response';
-
-interface PostResult {
-  updatedAt: string;
-  updatedCount: number;
-  insertedCount: number;
-}
 
 let dbClient: MongoClient;
 
@@ -177,6 +173,7 @@ export async function handler(
       updatedAt: dictionaryItem.updatedAt,
       updatedCount: dbResult.modifiedCount,
       insertedCount: dbResult.upsertedCount,
+      insertedIds: [dictionaryId],
     };
 
     return callback(null, Response.success({ ...postResult }));

--- a/webonary-cloud-api/lambda/postEntry.ts
+++ b/webonary-cloud-api/lambda/postEntry.ts
@@ -212,19 +212,13 @@
  */
 
 import { APIGatewayEvent, Callback, Context } from 'aws-lambda';
-import { MongoClient, ObjectId, UpdateWriteOpResult } from 'mongodb';
+import { MongoClient, UpdateWriteOpResult } from 'mongodb';
 import { connectToDB } from './mongo';
 import { DB_NAME, DB_COLLECTION_ENTRIES, DB_MAX_UPDATES_PER_CALL } from './db';
-import { DictionaryEntryItem } from './structs';
+import { PostResult } from './base.model';
+import { DictionaryEntryItem } from './entry.model';
 import { copyObjectIgnoreKeyCase } from './utils';
 import * as Response from './response';
-
-interface PostResult {
-  updatedAt: string;
-  updatedCount: number;
-  insertedCount: number;
-  insertedGUIDs: ObjectId[];
-}
 
 let dbClient: MongoClient;
 
@@ -296,10 +290,10 @@ export async function handler(
       updatedAt,
       updatedCount,
       insertedCount: insertedIds.length,
-      insertedGUIDs: insertedIds,
+      insertedIds: insertedIds.map(objectId => objectId.toString()),
     };
 
-    return callback(null, Response.success({ ...postResult }));
+    return callback(null, Response.success(postResult));
   } catch (error) {
     // eslint-disable-next-line no-console
     console.log(error);

--- a/webonary-cloud-api/lambda/searchEntries.ts
+++ b/webonary-cloud-api/lambda/searchEntries.ts
@@ -2,7 +2,8 @@ import { APIGatewayEvent, Context, Callback } from 'aws-lambda';
 import { MongoClient } from 'mongodb';
 import { connectToDB } from './mongo';
 import { DB_NAME, DB_COLLECTION_ENTRIES, DB_MAX_DOCUMENTS_PER_CALL } from './db';
-import { DbFindParameters, DbPaths } from './structs';
+import { DbFindParameters } from './base.model';
+import { DbPaths } from './entry.model';
 import { getDbSkip } from './utils';
 
 import * as Response from './response';

--- a/webonary-cloud-api/lambda/utils.ts
+++ b/webonary-cloud-api/lambda/utils.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { DictionaryEntry, EntryListOptionItem } from './structs';
+import { ListOptionItem } from './dictionary.model';
+import { DictionaryEntry } from './entry.model';
 
 export function hasKey<O>(obj: O, key: keyof any): key is keyof O {
   return key in obj;
@@ -73,7 +74,7 @@ export function copyObjectIgnoreKeyCase(toObject: object, fromObject: object): o
   return copyObject;
 }
 
-export function setSearchableEntries(entries: EntryListOptionItem[]): EntryListOptionItem[] {
+export function setSearchableEntries(entries: ListOptionItem[]): ListOptionItem[] {
   return entries.map(entry => {
     const newEntry = entry;
     if ('name' in entry && typeof entry.name === 'string' && entry.name !== '')

--- a/webonary-cloud-api/lambda_api_doc/api_project.json
+++ b/webonary-cloud-api/lambda_api_doc/api_project.json
@@ -18,7 +18,7 @@
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2020-05-21T20:43:22.497Z",
+    "time": "2020-05-21T22:18:15.270Z",
     "url": "http://apidocjs.com",
     "version": "0.20.1"
   }

--- a/webonary-cloud-api/lambda_api_doc/api_project.json
+++ b/webonary-cloud-api/lambda_api_doc/api_project.json
@@ -18,7 +18,7 @@
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2020-05-21T15:09:07.149Z",
+    "time": "2020-05-21T20:43:22.497Z",
     "url": "http://apidocjs.com",
     "version": "0.20.1"
   }

--- a/webonary-cloud-api/tools/flexXhtmlParser.ts
+++ b/webonary-cloud-api/tools/flexXhtmlParser.ts
@@ -1,13 +1,7 @@
 /* eslint-disable array-callback-return */
 import * as cheerio from 'cheerio';
-import {
-  EntryFile,
-  EntryValue,
-  DictionaryEntry,
-  DictionaryItem,
-  EntryListOption,
-  EntrySemanticDomain,
-} from '../lambda/structs';
+import { DictionaryEntry, EntryFile, EntryValue, EntrySemanticDomain } from '../lambda/entry.model';
+import { DictionaryItem, ListOption } from '../lambda/dictionary.model';
 
 export interface Options {
   dictionaryId: string;
@@ -267,7 +261,7 @@ export class FlexXhtmlParser {
       );
 
       loadDictionary.partsOfSpeech = this.parsedEntries.reduce(
-        (partsOfSpeech: EntryListOption[], entry) => {
+        (partsOfSpeech: ListOption[], entry) => {
           const newDictionaryPartsOfSpeech = partsOfSpeech;
           if (entry.morphoSyntaxAnalysis) {
             entry.morphoSyntaxAnalysis.partOfSpeech.forEach(entryPartOfSpeech => {
@@ -294,37 +288,34 @@ export class FlexXhtmlParser {
         [],
       );
 
-      loadDictionary.semanticDomains = this.parsedEntries.reduce(
-        (semDoms: EntryListOption[], entry) => {
-          const newDictionarySemDoms = semDoms;
-          entry.senses.forEach(sense => {
-            if (sense.semanticDomains && sense.semanticDomains.length) {
-              sense.semanticDomains.forEach(semDom => {
-                semDom.abbreviation.forEach(abbreviation => {
-                  const matchingName = semDom.name.find(item => item.lang === abbreviation.lang);
-                  if (matchingName) {
-                    const foundAbbreviation = newDictionarySemDoms.find(
-                      item =>
-                        item.abbreviation === abbreviation.value &&
-                        item.lang === abbreviation.lang &&
-                        item.name === matchingName.value,
-                    );
-                    if (!foundAbbreviation || foundAbbreviation.name !== matchingName.value) {
-                      newDictionarySemDoms.push({
-                        abbreviation: abbreviation.value,
-                        lang: matchingName.lang,
-                        name: matchingName.value,
-                      });
-                    }
+      loadDictionary.semanticDomains = this.parsedEntries.reduce((semDoms: ListOption[], entry) => {
+        const newDictionarySemDoms = semDoms;
+        entry.senses.forEach(sense => {
+          if (sense.semanticDomains && sense.semanticDomains.length) {
+            sense.semanticDomains.forEach(semDom => {
+              semDom.abbreviation.forEach(abbreviation => {
+                const matchingName = semDom.name.find(item => item.lang === abbreviation.lang);
+                if (matchingName) {
+                  const foundAbbreviation = newDictionarySemDoms.find(
+                    item =>
+                      item.abbreviation === abbreviation.value &&
+                      item.lang === abbreviation.lang &&
+                      item.name === matchingName.value,
+                  );
+                  if (!foundAbbreviation || foundAbbreviation.name !== matchingName.value) {
+                    newDictionarySemDoms.push({
+                      abbreviation: abbreviation.value,
+                      lang: matchingName.lang,
+                      name: matchingName.value,
+                    });
                   }
-                });
+                }
               });
-            }
-          });
-          return newDictionarySemDoms;
-        },
-        [],
-      );
+            });
+          }
+        });
+        return newDictionarySemDoms;
+      }, []);
     }
     return loadDictionary;
   }

--- a/webonary-cloud-api/tools/flexXhtmlParser.ts
+++ b/webonary-cloud-api/tools/flexXhtmlParser.ts
@@ -219,6 +219,7 @@ export class FlexXhtmlParser {
   public getDictionaryData(): DictionaryItem | undefined {
     const _id = this.options.dictionaryId;
 
+    console.log(_id);
     const loadDictionary = new DictionaryItem(_id);
 
     if (_id && this.parsedEntries.length) {

--- a/webonary-cloud-api/tools/post-legacy.ts
+++ b/webonary-cloud-api/tools/post-legacy.ts
@@ -3,7 +3,8 @@
 import axios, { AxiosBasicCredentials, AxiosResponse, AxiosError, AxiosRequestConfig } from 'axios';
 import * as mime from 'mime-types';
 import * as fs from 'fs';
-import { Dictionary, DictionaryEntry, EntryFile } from '../lambda/structs';
+import { Dictionary } from '../lambda/dictionary.model';
+import { DictionaryEntry, EntryFile } from '../lambda/entry.model';
 import fileGrabber from './fileGrabber';
 import { FlexXhtmlParser } from './flexXhtmlParser';
 


### PR DESCRIPTION
1. delete entry and dictionary api (latter deletes associated entries as well).
2. refactored structs.ts to base.model.ts, entry.model.ts, and dictionary.model.ts
3. refactored to put more logic into try block for type and parameter errors to appear and be passed on as error messages

Future todo: when deleting via api, entries and dictionaries get deleted, but the associated files are not yet deleted in S3. We might handle deletion of files through perhaps  a batch or triggered process, or real time through S3 api.