### PR TITLE
Display backend type in multisite site list and allow for searching

### DIFF
--- a/wordpress/wp-content/mu-plugins/webonary-backend-type.php
+++ b/wordpress/wp-content/mu-plugins/webonary-backend-type.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Plugin Name: Webonary Backend Type
+ * Description: View and search Webonary backend type in WordPress Multisite
+ * Version: 1.0.0
+ * Author: SIL International
+ * Author URI: http://www.sil.org/
+ * License: MIT
+ */
+
+! defined( 'ABSPATH' ) and exit;
+
+class webonary_backend_type {
+	public static function init() {
+		$class = __CLASS__ ;
+		if ( empty( $GLOBALS[ $class ] ) ) {
+			$GLOBALS[ $class ] = new $class;
+		}
+	}
+
+	public function __construct() {
+		add_filter( 'wpmu_blogs_columns', array( $this, 'add_backend_type' ) );
+		add_filter( 'ms_sites_list_table_query_args', array( $this, 'filter_site_search' ) );
+		add_action( 'manage_sites_custom_column', array( $this, 'get_backend_type' ), 10, 2 );
+	}
+
+	public function add_backend_type( $columns ) {
+		$columns['backend_type'] = __('Backend');
+
+		return $columns;
+	}
+
+	public function filter_site_search( $args ) {
+		if ( isset( $_REQUEST['s'] ) 
+		     && in_array( strtolower( $_REQUEST['s'] ), array( 'cloud', 'wordpress' ) ) ) {
+			global $wpdb;
+			$sql = $wpdb->prepare( "SELECT blog_id FROM {$wpdb->blogmeta} WHERE meta_key=%s AND meta_value=%s", "useCloudBackend", "1" );
+			if ( strtolower( $_REQUEST['s'] ) === 'wordpress' ) {
+				$sql = "SELECT blog_id FROM {$wpdb->blogs} WHERE blog_id NOT IN ({$sql})";
+			}
+
+			$blog_ids = $wpdb->get_col( $sql );
+			$args = array_merge( $args, [ 'site__in' => $blog_ids ] );
+			unset( $args[ 'search' ] );
+		}
+
+		return $args;
+	}
+
+	public function get_backend_type( $column_name, $blog_id ) {
+		if ( 'backend_type' === $column_name ) {
+			if ( get_site_meta($blog_id, 'useCloudBackend', true) ) {
+				echo __('Cloud');
+			}
+			else {
+				echo __('Wordpress');
+			}
+		}
+
+		return $column_name;
+	}
+
+}
+add_action( 'plugins_loaded', array( 'webonary_backend_type', 'init' ) );

--- a/wordpress/wp-content/plugins/sil-dictionary-webonary/include/configuration.php
+++ b/wordpress/wp-content/plugins/sil-dictionary-webonary/include/configuration.php
@@ -234,7 +234,10 @@ function save_configurations()
 				/** @noinspection PhpUndefinedFunctionInspection */
 				prune_super_cache(get_supercache_dir(), true);
 			}
+
+			// Store this both as a blog option and metadata for convenience
 			update_option('useCloudBackend', $useCloudBackend);
+			update_site_meta(get_current_blog_id(), 'useCloudBackend', '1');
 
 			// initial set up of dictionary using cloud values
 			if ($useCloudBackend) {

--- a/wordpress/wp-content/plugins/sil-dictionary-webonary/webonary/Webonary_Cloud.php
+++ b/wordpress/wp-content/plugins/sil-dictionary-webonary/webonary/Webonary_Cloud.php
@@ -444,7 +444,9 @@ class Webonary_Cloud
 			$uploadPath = $arrDirectory['path'];
 			self::setFontFaces($dictionary, $uploadPath);
 
+			// Store this both as a blog option and metadata for convenience
 			update_option('useCloudBackend', '1');
+			update_site_meta(get_id_from_blogname($dictionaryId), 'useCloudBackend', '1');
 		}
 	}
 }


### PR DESCRIPTION
In wp-admin/network/sites.php, a new column `Backend` has been added. 

Its value will be "Wordpress" for sites that use dictionary data stored in Wordpress, or "Cloud" for those that are set up to use the cloud backend.

![Screen Shot 2020-10-13 at 1 43 03 AM](https://user-images.githubusercontent.com/60716623/95824965-ca91b680-0cf5-11eb-9cc1-523a0af4e4fb.png)

To show only "Wordpress" or "Cloud" sites, you can now specify these words in the Search box.

![Screen Shot 2020-10-13 at 1 42 49 AM](https://user-images.githubusercontent.com/60716623/95825022-e1d0a400-0cf5-11eb-8aad-9a4d7e5ca80e.png)

