### PR TITLE
Fix loading order of style sheets

### DIFF
--- a/wordpress/wp-content/plugins/sil-dictionary-webonary/include/configuration.php
+++ b/wordpress/wp-content/plugins/sil-dictionary-webonary/include/configuration.php
@@ -252,6 +252,20 @@ function webonary_conf_dashboard()
 	webonary_conf_widget(true);
 }
 
+function webonary_register_custom_css()
+{
+	$upload_dir = wp_upload_dir();
+	wp_register_style(
+		'custom_stylesheet',
+		$upload_dir['baseurl'] . '/custom.css',
+		[],
+		date('U'),
+		'all'
+	);
+	wp_enqueue_style('custom_stylesheet');
+}
+add_action('wp_enqueue_scripts', 'webonary_register_custom_css', 999993);
+
 function webonary_conf_widget($showTitle = false)
 {
 	save_configurations();
@@ -264,8 +278,6 @@ function webonary_conf_widget($showTitle = false)
 	if(file_exists($configured_css_file))
 		$css_string = file_get_contents($configured_css_file);
 
-	wp_register_style('custom_css', $upload_dir['baseurl'] . '/custom.css?time=' . date("U"));
-	wp_enqueue_style('custom_css');
 
 	if(is_super_admin() && isset($_POST['uploadButton']))
 	{

--- a/wordpress/wp-content/plugins/sil-dictionary-webonary/include/dictionary-search.php
+++ b/wordpress/wp-content/plugins/sil-dictionary-webonary/include/dictionary-search.php
@@ -40,11 +40,16 @@ if ( ! defined('ABSPATH') )
 
 function my_enqueue_css() {
 
-	wp_register_style('webonary_dictionary_style', plugin_dir_url(__DIR__) . 'css/dictionary_styles.css', [], date('U'), 'all');
+	wp_register_style(
+		'webonary_dictionary_style',
+		plugin_dir_url(__DIR__) . 'css/dictionary_styles.css',
+		[],
+		date('U'),
+		'all'
+	);
 	wp_enqueue_style('webonary_dictionary_style');
 
 	// <link rel="stylesheet" href="<?php echo get_bloginfo('wpurl'); // >/wp-content/plugins/wp-page-numbers/classic/wp-page-numbers.css" />
-
 
 	if (is_page())
 		return;
@@ -52,24 +57,36 @@ function my_enqueue_css() {
 	if (get_option('useCloudBackend'))
 	{
 		$dictionaryId = Webonary_Cloud::getBlogDictionaryId();
-		Webonary_Cloud::registerAndEnqueueMainStyles($dictionaryId);
+		Webonary_Cloud::registerAndEnqueueMainStyles($dictionaryId, ['webonary_dictionary_style']);
 	}
 	else
 	{
 		$upload_dir = wp_upload_dir();
-		wp_register_style('configured_stylesheet', $upload_dir['baseurl'] . '/imported-with-xhtml.css?time=' . date('U'));
-		$overrides_css = $upload_dir['baseurl'] . '/ProjectDictionaryOverrides.css';
-		if(file_exists($overrides_css))
-		{
-			wp_register_style('overrides_stylesheet', $overrides_css . '?time=' . date('U'));
-		}
-		wp_enqueue_style( 'configured_stylesheet');
+		wp_register_style(
+			'configured_stylesheet',
+			$upload_dir['baseurl'] . '/imported-with-xhtml.css',
+			['webonary_dictionary_style'],
+			date('U'),
+			'all'
+		);
+		wp_enqueue_style('configured_stylesheet');
 
-		if(file_exists($upload_dir['basedir'] . '/ProjectDictionaryOverrides.css'))
+		$overrides_css = $upload_dir['basedir'] . '/ProjectDictionaryOverrides.css';
+		if (!file_exists($overrides_css))
+			$overrides_css = $upload_dir['baseurl'] . '/ProjectDictionaryOverrides.css';
+
+		if (file_exists($overrides_css))
 		{
-			wp_register_style('overrides_stylesheet', $upload_dir['baseurl'] . '/ProjectDictionaryOverrides.css?time=' . date('U'));
-			wp_enqueue_style( 'overrides_stylesheet');
+			wp_register_style(
+				'overrides_stylesheet',
+				$overrides_css,
+				['webonary_dictionary_style', 'configured_stylesheet'],
+				date('U'),
+				'all'
+			);
+			wp_enqueue_style('overrides_stylesheet');
 		}
+
 	}
 }
 

--- a/wordpress/wp-content/plugins/sil-dictionary-webonary/sil-dictionary.php
+++ b/wordpress/wp-content/plugins/sil-dictionary-webonary/sil-dictionary.php
@@ -78,7 +78,7 @@ add_filter('search_message', 'sil_dictionary_custom_message');
 add_filter('posts_request','replace_default_search_filter', 10, 2);
 
 // be sure these style sheets are loaded last, after the theme
-add_action('wp_enqueue_scripts', 'my_enqueue_css', 999999);
+add_action('wp_enqueue_scripts', 'my_enqueue_css', 999991);
 
 // this executes just before wordpress determines which template page to load
 add_action('template_redirect', 'Webonary_SearchCookie::GetSearchCookie');

--- a/wordpress/wp-content/plugins/sil-dictionary-webonary/sil-dictionary.php
+++ b/wordpress/wp-content/plugins/sil-dictionary-webonary/sil-dictionary.php
@@ -77,8 +77,10 @@ add_filter('search_message', 'sil_dictionary_custom_message');
 /* post query hooks */
 add_filter('posts_request','replace_default_search_filter', 10, 2);
 
+// be sure these style sheets are loaded last, after the theme
+add_action('wp_enqueue_scripts', 'my_enqueue_css', 999999);
+
 // this executes just before wordpress determines which template page to load
-add_action('template_redirect', 'my_enqueue_css');
 add_action('template_redirect', 'Webonary_SearchCookie::GetSearchCookie');
 
 // add_action('pre_get_posts','no_standard_sort');

--- a/wordpress/wp-content/plugins/sil-dictionary-webonary/webonary/Webonary_Cloud.php
+++ b/wordpress/wp-content/plugins/sil-dictionary-webonary/webonary/Webonary_Cloud.php
@@ -254,7 +254,7 @@ class Webonary_Cloud
 		return $posts;
 	}
 
-	public static function registerAndEnqueueMainStyles($dictionaryId) {
+	public static function registerAndEnqueueMainStyles($dictionaryId, $deps = array()) {
 		$dictionary = self::getDictionary($dictionaryId);
 		$time = strtotime($dictionary->updatedAt);
 		if (!is_null($dictionary)){
@@ -270,7 +270,7 @@ class Webonary_Cloud
 				}
 
 				$cssPath = $dictionaryId . '/' . $cssFile;
-				wp_register_style($handle, self::remoteFileUrl($cssPath), array(), $time);
+				wp_register_style($handle, self::remoteFileUrl($cssPath), $deps, $time);
 				wp_enqueue_style($handle);
 			}
 		}

--- a/wordpress/wp-content/themes/webonary-zeedisplay/functions.php
+++ b/wordpress/wp-content/themes/webonary-zeedisplay/functions.php
@@ -136,8 +136,8 @@ function themezee_stylesheets() {
 	wp_register_style('repsonive_menu_stylesheet', get_stylesheet_directory_uri() . '/includes/styles/responsive-menu.css?v=1');
 	wp_enqueue_style( 'repsonive_menu_stylesheet');
 
-	wp_register_style('custom_stylesheet', '/files/custom.css?time=' . date("U"));
-	wp_enqueue_style( 'custom_stylesheet');
+//	wp_register_style('custom_stylesheet', '/files/custom.css?time=' . date("U"));
+//	wp_enqueue_style( 'custom_stylesheet');
 }
 function themezee_enqueue_scripts() {
 


### PR DESCRIPTION
1. Template styles sheet
2. Webonary style sheet
3. Dictionary style sheet (imported)
4. Overrides style sheet

The main problem was the plugin was using the `template_redirect` hook rather than `wp_enqueue_scripts` to load styles, which fires before the template is loaded.

Resolves #150 