### PR TITLE
Show Browse Views in Webonary plugin page

### DIFF
--- a/wordpress/wp-content/plugins/sil-dictionary-webonary/include/configuration.php
+++ b/wordpress/wp-content/plugins/sil-dictionary-webonary/include/configuration.php
@@ -296,7 +296,6 @@ function webonary_conf_widget($showTitle = false)
 	if(isset($_POST['btnSaveRelevance']))
 		relevanceSave();
 
-	$import_status = '';
 	$arrLanguageCodes = array();
 	$noReversalEntries = true;
 	if (get_option('useCloudBackend')) {
@@ -320,8 +319,8 @@ function webonary_conf_widget($showTitle = false)
 					$noReversalEntries = false;
 				}
 			}
+			$import_status = '<ul>' . $import_status . '</ul>';
 		}
-		$import_status = '<ul>' . $import_status . '</ul>';
 	}
 	else {
 		$import_status = Webonary_Info::import_status();

--- a/wordpress/wp-content/plugins/sil-dictionary-webonary/include/configuration.php
+++ b/wordpress/wp-content/plugins/sil-dictionary-webonary/include/configuration.php
@@ -296,6 +296,39 @@ function webonary_conf_widget($showTitle = false)
 	if(isset($_POST['btnSaveRelevance']))
 		relevanceSave();
 
+	$import_status = '';
+	$arrLanguageCodes = array();
+	$noReversalEntries = true;
+	if (get_option('useCloudBackend')) {
+		$dictionary_id = Webonary_Cloud::getBlogDictionaryId();
+		$dictionary = Webonary_Cloud::getDictionary($dictionary_id);
+		$import_status = '';
+		if (!is_null($dictionary)) {
+			$import_status .= '<li>Last Import: <em>' . $dictionary->updatedAt . '</em>';
+			$import_status .= '<li>Main Language (' . $dictionary->mainLanguage->lang . ')';
+			$import_status .= ' entries: <em>' . number_format($dictionary->mainLanguage->entriesCount) . '</em>';
+			$arrLanguageCodes[] = array(
+				'language_code' => $dictionary->mainLanguage->lang,
+				'name' => $dictionary->mainLanguage->title ?? $dictionary->mainLanguage->lang);
+			foreach ($dictionary->reversalLanguages as $reversal) {
+				$import_status .= '<li>Reversal Language (' . $reversal->lang . ')';
+				if (isset($reversal->entriesCount) && $reversal->entriesCount) {
+					$import_status .= ' entries: <em>'. number_format($reversal->entriesCount) . '</em>';
+					$arrLanguageCodes[] = array(
+						'language_code' => $reversal->lang,
+						'name' => $reversal->title ?? $reversal->lang);
+					$noReversalEntries = false;
+				}
+			}
+		}
+		$import_status = '<ul>' . $import_status . '</ul>';
+	}
+	else {
+		$import_status = Webonary_Info::import_status();
+		$arrLanguageCodes = Webonary_Configuration::get_LanguageCodes();
+		if (count(getReversalEntries("", 0, "", true, "")))
+			$noReversalEntries = false;
+	}
 	?>
 	<script src="<?php echo get_bloginfo('wpurl'); ?>/wp-content/plugins/sil-dictionary-webonary/js/options.js" type="text/javascript"></script>
 	<style>
@@ -324,8 +357,6 @@ function webonary_conf_widget($showTitle = false)
 			echo '<a class="nav-tab" href="#'.$slug.'" title="'.sprintf(__('Click to switch to %s', 'sil_dictionary'), $name).'">'.$name.'</a>' . PHP_EOL;
 		}
 		echo '</h2>' . PHP_EOL;
-
-		$arrLanguageCodes = Webonary_Configuration::get_LanguageCodes();
 
 		// enctype="multipart/form-data"
 		?>
@@ -361,28 +392,7 @@ function webonary_conf_widget($showTitle = false)
 			<form method="post" action="admin.php?import=pathway-xhtml&step=2">
 				<div style="max-width: 600px; border-style:solid; border-width: 1px; border-color: red; padding: 5px;">
 					<strong>Import Status:</strong>
-					<?php
-					if (get_option('useCloudBackend')) {
-						$dictionary_id = Webonary_Cloud::getBlogDictionaryId();
-						$dictionary = Webonary_Cloud::getDictionary($dictionary_id);
-						$import_status = '';
-						if (!is_null($dictionary)) {
-							$import_status .= '<li>Last Import: <em>' . $dictionary->updatedAt . '</em>';
-							$import_status .= '<li>Main Language (' . $dictionary->mainLanguage->lang . ')';
-							$import_status .= ' entries: <em>' . number_format($dictionary->mainLanguage->entriesCount) . '</em>';
-							foreach ($dictionary->reversalLanguages as $reversal) {
-								$import_status .= '<li>Reversal Language (' . $reversal->lang . ')';
-								if (isset($reversal->entriesCount) && $reversal->entriesCount) {
-									$import_status .= ' entries: <em>'. number_format($reversal->entriesCount) . '</em>';
-								}
-							}
-						}
-						echo '<ul>' . $import_status . '</ul>';
-					}
-					else {
-						echo Webonary_Info::import_status();
-					}
-                	?>
+					<?php echo $import_status ?>
 				</div>
 			</form>
 
@@ -612,10 +622,7 @@ function webonary_conf_widget($showTitle = false)
 				</p>
 
 			<?php
-			$displayXHTML = true;
-			$reversalEntries = getReversalEntries("", 0, "", $displayXHTML, "");
-
-			if(count($reversalEntries) == 0)
+			if($noReversalEntries)
 			{
 				echo 'No reversal indexes imported.';
 			}

--- a/wordpress/wp-content/plugins/sil-dictionary-webonary/include/configuration.php
+++ b/wordpress/wp-content/plugins/sil-dictionary-webonary/include/configuration.php
@@ -326,7 +326,9 @@ function webonary_conf_widget($showTitle = false)
 	else {
 		$import_status = Webonary_Info::import_status();
 		$arrLanguageCodes = Webonary_Configuration::get_LanguageCodes();
-		if (count(getReversalEntries("", 0, "", true, "")))
+		$displayXHTML = true;
+		$reversalEntries = getReversalEntries("", 0, "", $displayXHTML, "");
+		if (count($reversalEntries))
 			$noReversalEntries = false;
 	}
 	?>


### PR DESCRIPTION
When a new dictionary project is uploaded to the cloud backend, it should show the main language and reversal languages config settings in the Browse View section of the Webonary plugin page, e.g.
![Screen Shot 2020-11-25 at 4 56 46 PM](https://user-images.githubusercontent.com/60716623/100289744-3c892c80-2f3f-11eb-9abd-64ac2d329913.png)
