### PR TITLE
Fix warnings received when restoring a database to a different server

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This is the format of the short-code tag:
 ### How to get uploaded site files
 
 ```
-rsync -avz --chmod=D2775,F664 -e 'ssh -i ~/.ssh/id_rsa -o IdentitiesOnly=yes' your_name@server_name.org:/var/www/webonary.org/htdocs/wp/wp-content/blogs.dir /var/www/projects/webonary2/wordpress/wp-content
+rsync -avz --chmod=D2775,F664 -e 'ssh -i ~/.ssh/id_rsa -o IdentitiesOnly=yes' your_name@server_name.org:/var/www/sites/webonary/shared/blogs.dir /var/www/projects/webonary2/wordpress/wp-content
 ```
 
 

--- a/wp-resources/plugins/q-and-a/inc/custom-post.php
+++ b/wp-resources/plugins/q-and-a/inc/custom-post.php
@@ -1,9 +1,10 @@
-<?php 
+<?php
 add_action( 'init', 'create_qa_post_types', 0 );
 function create_qa_post_types() {
-	 
+
 	 global $qaplus_options;
-	 
+	 $slug = strtolower($qaplus_options['faq_slug'] ?? 'faqs');
+
 	 $labels = array(
 		'name' => _x( 'FAQ Categories', 'qa-free' ),
 		'singular_name' => _x( 'FAQ Category', 'qa-free'),
@@ -11,7 +12,7 @@ function create_qa_post_types() {
 		'all_items' => __( 'All FAQ Categories', 'qa-free' ),
 		'parent_item' => __( 'Parent FAQ Category', 'qa-free' ),
 		'parent_item_colon' => __( 'Parent FAQ Category:', 'qa-free'),
-		'edit_item' => __( 'Edit FAQ Category', 'qa-free'), 
+		'edit_item' => __( 'Edit FAQ Category', 'qa-free'),
 		'update_item' => __( 'Update FAQ Category', 'qa-free'),
 		'add_new_item' => __( 'Add New FAQ Category', 'qa-free'),
 		'new_item_name' => __( 'New FAQ Category Name', 'qa-free')
@@ -28,12 +29,12 @@ function create_qa_post_types() {
 			'public' => true,
 			'show_ui' => true,
 			'capability_type' => 'post',
-			'rewrite' => array( 'slug' => $qaplus_options['faq_slug'], 'with_front' => false ),
+			'rewrite' => array( 'slug' => $slug, 'with_front' => false ),
 			'taxonomies' => array( 'FAQs '),
-			'supports' => array('title','editor')	
+			'supports' => array('title','editor')
 		)
-	); 	
-  
+	);
+
   	register_taxonomy('faq_category',array('qa_faqs'), array(
 		'hierarchical' => true,
 		'labels' => $labels,
@@ -41,17 +42,17 @@ function create_qa_post_types() {
 		'query_var' => true,
 		'rewrite' => array( 'slug' => 'faq-category' ),
   ));
-  
-}	
+
+}
 
 add_action('restrict_manage_posts','restrict_listings_by_categories');
 function restrict_listings_by_categories() {
     global $typenow;
     global $wp_query;
     if ($typenow=='qa_faqs') {
-        
+
 		$tax_slug = 'faq_category';
-        
+
 		// retrieve the taxonomy object
 		$tax_obj = get_taxonomy($tax_slug);
 		$tax_name = $tax_obj->labels->name;
@@ -96,7 +97,6 @@ function qa_show_columns($name) {
 			}
 			break;
 		default :
-			break;	
+			break;
 	}
 }
-

--- a/wp-resources/plugins/q-and-a/inc/functions.php
+++ b/wp-resources/plugins/q-and-a/inc/functions.php
@@ -45,15 +45,15 @@ add_filter( 'plugin_action_links', 'qaplus_action_links', 10, 2 );
 
 function qaplus_rewrites() {
 	global $qaplus_options;
-	if ( ! $qaplus_options['faq_slug'] ) { $slug = 'faqs'; } else { $slug = strtolower( $qaplus_options['faq_slug'] ); }
+	$slug = strtolower($qaplus_options['faq_slug'] ?? 'faqs');
 
-	add_rewrite_rule( $qaplus_options['faq_slug'] . '/search/?([^/]*)','index.php?s=$matches[1]&post_type=qa_faqs','top');
+	add_rewrite_rule( $slug . '/search/?([^/]*)','index.php?s=$matches[1]&post_type=qa_faqs','top');
 
-	add_rewrite_rule( $qaplus_options['faq_slug'] . '/page/?([^/]*)','index.php?pagename=' . $qaplus_options['faq_slug'] . '&paged=$matches[1]','top');
+	add_rewrite_rule( $slug . '/page/?([^/]*)','index.php?pagename=' . $slug . '&paged=$matches[1]','top');
 
-	add_rewrite_rule( $qaplus_options['faq_slug'] . '/category/?([^/]*)/page/?([^/]*)','index.php?pagename=' . $qaplus_options['faq_slug'] . '&category_name=$matches[1]&paged=$matches[2]','top');
+	add_rewrite_rule( $slug . '/category/?([^/]*)/page/?([^/]*)','index.php?pagename=' . $slug . '&category_name=$matches[1]&paged=$matches[2]','top');
 
-	add_rewrite_rule( $qaplus_options['faq_slug'] . '/category/?([^/]*)','index.php?pagename=' . $qaplus_options['faq_slug'] . '&category_name=$matches[1]','top');
+	add_rewrite_rule( $slug . '/category/?([^/]*)','index.php?pagename=' . $slug . '&category_name=$matches[1]','top');
 
 }
 
@@ -67,18 +67,22 @@ if ( ! is_admin() ) {
 
 function qaplus_public() {
 	global $qaplus_options;
+
+	$version = $qaplus_options['version'] ?? '0.0.0';
+	$jquery = $qaplus_options['jquery'] ?? '';
+
 	// jQuery
-	if ( $qaplus_options['jquery'] == "force" ) {
+	if ( $jquery == 'force' ) {
 		wp_deregister_script( 'jquery' );
-		wp_register_script( 'jquery', ( "http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js" ), false, '1', false);
+		wp_register_script( 'jquery', ( 'http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js' ), false, '1', false);
 		wp_enqueue_script( 'jquery' );
-	} elseif ( $qaplus_options['jquery'] == "wp" ) {
+	} elseif ( $jquery == 'wp' ) {
 		wp_enqueue_script( 'jquery' );
 	}
 
-	wp_enqueue_script( 'q-a-plus', Q_A_PLUS_URL . '/js/q-a-plus.js', false, $qaplus_options['version'], true );
+	wp_enqueue_script( 'q-a-plus', Q_A_PLUS_URL . '/js/q-a-plus.js', false, $version, true );
 
-	wp_enqueue_style( 'q-a-plus', Q_A_PLUS_URL . '/css/q-a-plus.css', false, $qaplus_options['version'], 'screen' );
+	wp_enqueue_style( 'q-a-plus', Q_A_PLUS_URL . '/css/q-a-plus.css', false, $version, 'screen' );
 }
 
 add_action( 'wp_head', 'qaplus_head' );

--- a/wp-resources/plugins/slider-image/slider.php
+++ b/wp-resources/plugins/slider-image/slider.php
@@ -1,4 +1,5 @@
 <?php
+/** @noinspection PhpMissingReturnTypeInspection */
 
 /*
 Plugin Name: Huge IT Slider
@@ -259,9 +260,9 @@ final class Hugeit_Slider {
 	 */
 	private function __clone() {}
 
-	private function __sleep() {}
+	public function __sleep() {}
 
-	private function __wakeup()	{}
+	public function __wakeup()	{}
 
 	/**
 	 * Get plugin version.


### PR DESCRIPTION
The script to update the host name is giving null array warnings for the updated lines.

Also, `__sleep()` and `__wakeup()` must be public.