### PR TITLE
update lambda node version to 14.x

### DIFF
--- a/webonary-cloud-api/lib/webonary-cloud-api-stack.ts
+++ b/webonary-cloud-api/lib/webonary-cloud-api-stack.ts
@@ -8,7 +8,7 @@ import { envSpecific } from './config';
 
 function defaultLambdaFunctionProps(functionName: string, environment = {}): lambda.FunctionProps {
   const props: lambda.FunctionProps = {
-    runtime: lambda.Runtime.NODEJS_12_X,
+    runtime: lambda.Runtime.NODEJS_14_X,
     code: new lambda.AssetCode('lambda'),
     handler: `${functionName}.handler`,
     timeout: cdk.Duration.seconds(60),


### PR DESCRIPTION
Lambdas were erroring because we updated the project to node 14.x, but did not specify that in the Lambda create functions in CDK:

```
"errorType": "Runtime.ImportModuleError",
"errorMessage": "Error: Cannot find module
```
