### PR TITLE
When removing HTML from displayXhtml, treat div tags as word separators.

### DIFF
--- a/webonary-cloud-api/lambda/__tests__/searchEntries.test.ts
+++ b/webonary-cloud-api/lambda/__tests__/searchEntries.test.ts
@@ -71,6 +71,35 @@ describe('searchEntries', () => {
     expect(parseGuids(response)).toEqual([matchingGuid]);
   });
 
+  test('tags are treated as word boundaries', async () => {
+    const dictionaryId = await createDictionary();
+    const matchingGuid = 'test-matching-guid';
+    await upsertEntries(
+      [
+        {
+          guid: matchingGuid,
+          displayXhtml: `abc`,
+        },
+        {
+          guid: 'test-not-matching-guid',
+          displayXhtml: `a<div>b</div>c`,
+        },
+      ],
+      false,
+      dictionaryId,
+      testUsername,
+    );
+
+    const response = await searchEntries({
+      ...defaultArguments,
+      dictionaryId,
+      text: 'abc',
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(parseGuids(response)).toEqual([matchingGuid]);
+  });
+
   test('does not match tags in displayXhtml', async () => {
     const dictionaryId = await createDictionary();
     await upsertEntries(

--- a/webonary-cloud-api/lambda/__tests__/searchEntries.test.ts
+++ b/webonary-cloud-api/lambda/__tests__/searchEntries.test.ts
@@ -73,16 +73,19 @@ describe('searchEntries', () => {
 
   test('tags are treated as word boundaries', async () => {
     const dictionaryId = await createDictionary();
-    const matchingGuid = 'test-matching-guid';
     await upsertEntries(
       [
         {
-          guid: matchingGuid,
+          guid: 'test-matching-guid-1',
           displayXhtml: `abc`,
         },
         {
-          guid: 'test-not-matching-guid',
-          displayXhtml: `a<div>b</div>c`,
+          guid: 'test-matching-guid-2',
+          displayXhtml: `<span>abc</span><span>something else</span>`,
+        },
+        {
+          guid: 'test-not-matching-guid-1',
+          displayXhtml: `a<div>bc</div> a<span>bc</span>`,
         },
       ],
       false,
@@ -97,7 +100,7 @@ describe('searchEntries', () => {
     });
 
     expect(response.statusCode).toBe(200);
-    expect(parseGuids(response)).toEqual([matchingGuid]);
+    expect(parseGuids(response)).toEqual(['test-matching-guid-1', 'test-matching-guid-2']);
   });
 
   test('does not match tags in displayXhtml', async () => {

--- a/webonary-cloud-api/lambda/package-lock.json
+++ b/webonary-cloud-api/lambda/package-lock.json
@@ -4,11 +4,25 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@selderee/plugin-htmlparser2": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.6.0.tgz",
+      "integrity": "sha512-J3jpy002TyBjd4N/p6s+s90eX42H2eRhK3SbsZuvTDv977/E8p2U3zikdiehyJja66do7FlxLomZLPlvl2/xaA==",
+      "requires": {
+        "domhandler": "^4.2.0",
+        "selderee": "^0.6.0"
+      }
+    },
     "@types/aws-lambda": {
       "version": "8.10.101",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.101.tgz",
       "integrity": "sha512-84geGyVc0H9P9aGbcg/vkDh5akJq0bEf3tizHNR2d1gcm0wsp9IZ/SW6rPxvgjJFi3OeVxDc8WTKCAjoZbogzg==",
       "dev": true
+    },
+    "@types/html-to-text": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@types/html-to-text/-/html-to-text-8.1.0.tgz",
+      "integrity": "sha512-54YF2fGmN4g62/w+T85uQ8n0FyBhMY5cjKZ1imsbIh4Pgbeno1mAaQktC/pv/+C2ToUYkTZis9ADgn9GRRz9nQ=="
     },
     "@types/node": {
       "version": "18.0.4",
@@ -216,6 +230,11 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
       "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w=="
     },
+    "discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ=="
+    },
     "dom-serializer": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
@@ -301,11 +320,6 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
-    },
-    "escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
     },
     "esprima": {
       "version": "4.0.1",
@@ -444,6 +458,24 @@
         "has-symbols": "^1.0.2"
       }
     },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+    },
+    "html-to-text": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-8.2.1.tgz",
+      "integrity": "sha512-aN/3JvAk8qFsWVeE9InWAWueLXrbkoVZy0TkzaGhoRBC2gCFEeRLDDJN3/ijIGHohy6H+SZzUQWN/hcYtaPK8w==",
+      "requires": {
+        "@selderee/plugin-htmlparser2": "^0.6.0",
+        "deepmerge": "^4.2.2",
+        "he": "^1.2.0",
+        "htmlparser2": "^6.1.0",
+        "minimist": "^1.2.6",
+        "selderee": "^0.6.0"
+      }
+    },
     "htmlparser2": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
@@ -544,11 +576,6 @@
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
-    },
-    "is-plain-object": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
     },
     "is-regex": {
       "version": "1.1.4",
@@ -696,15 +723,33 @@
         "whatwg-url": "^11.0.0"
       }
     },
-    "nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
+    "moo": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
+      "integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w=="
     },
     "napi-build-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
       "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
+    },
+    "nearley": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+      "requires": {
+        "commander": "^2.19.0",
+        "moo": "^0.5.0",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        }
+      }
     },
     "node-abi": {
       "version": "3.22.0",
@@ -748,24 +793,13 @@
         "wrappy": "1"
       }
     },
-    "parse-srcset": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
-      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="
-    },
-    "picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
-    },
-    "postcss": {
-      "version": "8.4.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
-      "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
+    "parseley": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.7.0.tgz",
+      "integrity": "sha512-xyOytsdDu077M3/46Am+2cGXEKM9U9QclBDv7fimY7e+BBlxh2JcBp2mgNsmkyA9uvgyTjVzDi7cP1v4hcFxbw==",
       "requires": {
-        "nanoid": "^3.3.4",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "moo": "^0.5.1",
+        "nearley": "^2.20.1"
       }
     },
     "prebuild-install": {
@@ -806,6 +840,20 @@
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g=="
     },
+    "railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A=="
+    },
+    "randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "requires": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      }
+    },
     "rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -837,23 +885,15 @@
         "functions-have-names": "^1.2.2"
       }
     },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+    },
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-    },
-    "sanitize-html": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.7.0.tgz",
-      "integrity": "sha512-jfQelabOn5voO7FAfnQF7v+jsA6z9zC/O4ec0z3E35XPEtHYJT/OdUziVWlKW4irCr2kXaQAyXTXDHWAibg1tA==",
-      "requires": {
-        "deepmerge": "^4.2.2",
-        "escape-string-regexp": "^4.0.0",
-        "htmlparser2": "^6.0.0",
-        "is-plain-object": "^5.0.0",
-        "parse-srcset": "^1.0.2",
-        "postcss": "^8.3.11"
-      }
     },
     "saslprep": {
       "version": "1.0.3",
@@ -868,6 +908,14 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
       "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA=="
+    },
+    "selderee": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.6.0.tgz",
+      "integrity": "sha512-ibqWGV5aChDvfVdqNYuaJP/HnVBhlRGSRrlbttmlMpHcLuTqqbMH36QkSs9GEgj5M88JDYLI8eyP94JaQ8xRlg==",
+      "requires": {
+        "parseley": "^0.7.0"
+      }
     },
     "semver": {
       "version": "7.3.7",
@@ -915,11 +963,6 @@
         "ip": "^1.1.5",
         "smart-buffer": "^4.2.0"
       }
-    },
-    "source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
     },
     "sparse-bitfield": {
       "version": "3.0.3",

--- a/webonary-cloud-api/lambda/package.json
+++ b/webonary-cloud-api/lambda/package.json
@@ -5,11 +5,12 @@
     "@types/aws-lambda": "^8.10.101"
   },
   "dependencies": {
+    "@types/html-to-text": "^8.1.0",
     "aws-lambda": "^1.0.6",
     "aws-sdk": "^2.691.0",
     "axios": "^0.27.2",
+    "html-to-text": "^8.2.1",
     "mongodb": "^4.7.0",
-    "mongodb-client-encryption": "^2.1.0",
-    "sanitize-html": "^2.7.0"
+    "mongodb-client-encryption": "^2.1.0"
   }
 }

--- a/webonary-cloud-api/lambda/postEntry.ts
+++ b/webonary-cloud-api/lambda/postEntry.ts
@@ -213,7 +213,7 @@
 
 import { APIGatewayEvent, Callback, Context } from 'aws-lambda';
 import { MongoClient, UpdateResult } from 'mongodb';
-import sanitizeHtml from 'sanitize-html';
+import { compile as compileHtmlToText } from 'html-to-text';
 import { connectToDB } from './mongo';
 import {
   MONGO_DB_NAME,
@@ -237,12 +237,9 @@ let dbClient: MongoClient;
 /**
  * Removes any HTML from a string.
  */
-function stripHtml(html: string): string {
-  return sanitizeHtml(html, {
-    allowedTags: [],
-    allowedAttributes: {},
-  });
-}
+const stripHtml = compileHtmlToText({
+  selectors: [{ selector: 'a', format: 'inline' }], // don't display href attributes of links
+});
 
 /**
  * Fills in empty DictionaryEntry fields from other fields that were supplied.

--- a/webonary-cloud-api/lambda/postEntry.ts
+++ b/webonary-cloud-api/lambda/postEntry.ts
@@ -238,7 +238,12 @@ let dbClient: MongoClient;
  * Removes any HTML from a string.
  */
 const stripHtml = compileHtmlToText({
-  selectors: [{ selector: 'a', format: 'inline' }], // don't display href attributes of links
+  selectors: [
+    // don't display href attributes of links
+    { selector: 'a', format: 'inline' },
+    // treat span tags as word separators
+    { selector: 'span', format: 'paragraph' },
+  ],
 });
 
 /**


### PR DESCRIPTION
The issue was that https://www.webonary.work/test-peacock2/gdfb365e9-ce7a-4678-a53e-70904aaf4dcc/ was not showing up when searching for "seeme" and matching whole words because `sanitize-html` was converting the following `displayXhtml` to "seemeipf. 1st. ofsíVI will go; I am going", concatenating "seeme" and "ipf"


`<div class="minorentrycomplex" id="gdfb365e9-ce7a-4678-a53e-70904aaf4dcc"><span class="headword"><span lang="dsh"><a href="#gdfb365e9-ce7a-4678-a53e-70904aaf4dcc">seeme</a></span></span><span class="complexformentryrefs"><span class="complexformentryref"><span class="complexformtypes"><span class="complexformtype"><span class="reverseabbr"><span lang="en">ipf. 1st. of</span></span></span></span><span class="referencedentries"><span class="referencedentry"><span class="headword"><span lang="dsh"><a href="#g74cc36a7-4917-4c1f-9d30-600b8a38eacd">sí</a></span></span></span></span></span></span><span class="senses"><span class="sharedgrammaticalinfo"><span class="morphosyntaxanalysis"><span class="partofspeech"><span lang="en">V</span></span></span></span><span class="sensecontent"><span class="sense" entryguid="gdfb365e9-ce7a-4678-a53e-70904aaf4dcc"><span class="definitionorgloss"><span lang="en">I will go; I am going</span></span></span></span></span></div>`

https://github.com/apostrophecms/sanitize-html/issues/394#issuecomment-670071166 suggested using html-to-text instead.