### PR TITLE
Fix missing required arg 'permission_callback'

### DIFF
--- a/wp-resources/plugins/sil-dictionary-webonary/webonary/Webonary_API_MyType.php
+++ b/wp-resources/plugins/sil-dictionary-webonary/webonary/Webonary_API_MyType.php
@@ -9,7 +9,12 @@ class Webonary_API_MyType
 
 		register_rest_route($namespace, '/import', array(
 				'methods' => WP_REST_Server::CREATABLE,
-				'callback' => 'Webonary_API_MyType::Import'
+				'callback' => 'Webonary_API_MyType::Import',
+				'permission_callback' => function() {
+					$data = get_userdata(get_current_user_id());
+					$role = $data->roles;
+					return (is_super_admin() || (isset($role[0]) && $role[0] == "administrator"));
+				}
 			)
 		);
 
@@ -20,6 +25,7 @@ class Webonary_API_MyType
 				'methods' => WP_REST_Server::READABLE,
 				'callback' => 'Webonary_API_MyType::Query',
 				'args' => array(),
+				'permission_callback' => '__return_true'
 			)
 		);
 	}

--- a/wp-resources/plugins/sil-dictionary-webonary/webonary/Webonary_Cloud.php
+++ b/wp-resources/plugins/sil-dictionary-webonary/webonary/Webonary_Cloud.php
@@ -399,13 +399,15 @@ class Webonary_Cloud
 	public static function registerApiRoutes() {
 		register_rest_route(self::$apiNamespace, '/validate', array(
 				'methods' => WP_REST_Server::CREATABLE,
-				'callback' => __CLASS__ . '::apiValidate'
+				'callback' => __CLASS__ . '::apiValidate',
+				'permission_callback' => '__return_true'
 			)
 		);
 
 		register_rest_route(self::$apiNamespace, '/resetDictionary', array(
 				'methods' => WP_REST_Server::CREATABLE,
-				'callback' => __CLASS__ . '::apiResetDictionary'
+				'callback' => __CLASS__ . '::apiResetDictionary',
+				'permission_callback' => '__return_true'
 			)
 		);
 	}


### PR DESCRIPTION
This is the message:

Notice: Function register_rest_route was called incorrectly.
The REST API route definition for webonary-cloud/v1/validate
is missing the required 'permission_callback' argument.
For REST API routes that are intended to be public,
use '__return_true' as the permission callback.