### PR TITLE
Sort according to display text instead of main head word.

### DIFF
--- a/webonary-cloud-api/lambda/__tests__/searchEntries.test.ts
+++ b/webonary-cloud-api/lambda/__tests__/searchEntries.test.ts
@@ -369,7 +369,7 @@ describe('searchEntries', () => {
       matchAccents: false,
     });
 
-    expect(parseGuids(response)).toEqual(['accent', 'no-accent']);
+    expect(parseGuids(response)).toEqual(['no-accent', 'accent']);
   });
 
   test('!matchAccents with accented search matches all accents and tones', async () => {
@@ -397,7 +397,7 @@ describe('searchEntries', () => {
       matchAccents: false,
     });
 
-    expect(parseGuids(response)).toEqual(['accent', 'no-accent']);
+    expect(parseGuids(response)).toEqual(['no-accent', 'accent']);
   });
 
   test('matchAccents filters out accents and tones', async () => {
@@ -499,11 +499,6 @@ describe('searchEntries', () => {
       [
         {
           guid: 'sorted-match-partial-2',
-          mainHeadWord: [
-            {
-              value: 'b',
-            },
-          ],
           displayXhtml: `b text`,
         },
         {
@@ -511,6 +506,9 @@ describe('searchEntries', () => {
           mainHeadWord: [
             {
               value: 'c',
+            },
+            {
+              value: '0',
             },
           ],
           displayXhtml: `c text`,
@@ -550,11 +548,6 @@ describe('searchEntries', () => {
       [
         {
           guid: 'sorted-match-partial-2',
-          mainHeadWord: [
-            {
-              value: 'b',
-            },
-          ],
           displayXhtml: `b text`,
         },
         {
@@ -562,6 +555,9 @@ describe('searchEntries', () => {
           mainHeadWord: [
             {
               value: 'c',
+            },
+            {
+              value: '0',
             },
           ],
           displayXhtml: `c text`,

--- a/webonary-cloud-api/lambda/searchEntries.ts
+++ b/webonary-cloud-api/lambda/searchEntries.ts
@@ -165,7 +165,7 @@ export async function searchEntries(args: SearchEntriesArguments): Promise<Respo
         .collection(DB_COLLECTION_DICTIONARY_ENTRIES)
         .find(dictionaryPartialSearch)
         .collation({ locale, strength })
-        .sort({ 'mainHeadWord.value': 1, _id: 1 })
+        .sort({ displayText: 1, _id: 1 })
         .skip(dbSkip)
         .limit(args.pageLimit)
         .toArray();
@@ -197,7 +197,7 @@ export async function searchEntries(args: SearchEntriesArguments): Promise<Respo
       entries = await db
         .collection(DB_COLLECTION_DICTIONARY_ENTRIES)
         .find(dictionaryFulltextSearch)
-        .sort({ 'mainHeadWord.value': 1, _id: 1 })
+        .sort({ displayText: 1, _id: 1 })
         .skip(dbSkip)
         .limit(args.pageLimit)
         .toArray();


### PR DESCRIPTION
The data for main head word can be weird. Sometimes there are no main head words, and sometimes there are multiple, with integer values. It would be nice to fix this data, but until then, let's just not use it.

The main change is to sort by `displayText` instead of `mainHeadWord.value`. I'm also changing the test data to fit what we see in production. The order in some existing tests also need to be updated.

Fixes #397