### PR TITLE
428 display all sites ends up timing out

### DIFF
--- a/wp-resources/plugins/sil-dictionary-webonary/webonary/Webonary_Cloud.php
+++ b/wp-resources/plugins/sil-dictionary-webonary/webonary/Webonary_Cloud.php
@@ -236,10 +236,19 @@ class Webonary_Cloud {
     }
 
     public static function getDictionary($dictionaryId) {
-        $request = self::$doGetDictionary . '/' . $dictionaryId;
-        $response = self::remoteGetJson($request);
+		$dictionary = get_option('dictionary');
+		if (!empty($dictionary)) {
+			return $dictionary;
+		}
 
-        return (self::isValidDictionary($response)) ? $response : null;
+		$request = self::$doGetDictionary . '/' . $dictionaryId;
+		$response = self::remoteGetJson($request);
+		if (self::isValidDictionary($response)) {
+			update_option('dictionary', $response);
+			return $response;
+		}
+
+        return null;
     }
 
     public static function getTotalCount($doAction, $dictionaryId, $apiParams = array()): int {
@@ -465,7 +474,10 @@ class Webonary_Cloud {
     }
 
     public static function resetDictionary($dictionaryId) {
-        $dictionary = self::getDictionary($dictionaryId);
+		// Since dictionary is persisted in options, unset it first
+		delete_option('dictionary');
+
+		$dictionary = self::getDictionary($dictionaryId);
         if (!is_null($dictionary)) {
             $language = $dictionary->mainLanguage;
             update_option('languagecode', $language->lang);

--- a/wp-resources/plugins/sil-dictionary-webonary/webonary/Webonary_Excel.php
+++ b/wp-resources/plugins/sil-dictionary-webonary/webonary/Webonary_Excel.php
@@ -181,7 +181,7 @@ class Webonary_Excel
 		$rows = [];
 
 		if ($include_header_row)
-			$rows[] = ['SiteTitle', 'Country', 'URL', 'Copyright', 'Code', 'Backend', 'Entries', 'CreateDate', 'PublishDate', 'ContactEmail', 'Notes', 'LastUpload'];
+			$rows[] = ['SiteTitle', 'Country', 'URL', 'Copyright', 'Code', 'Backend', 'Entries', 'CreateDate', 'PublishDate', 'ContactEmail', 'LastUpload', 'Notes'];
 
 		$sql =  "SELECT blog_id, domain, DATE_FORMAT(registered, '%Y-%m-%d') AS registered FROM $wpdb->blogs
     WHERE blog_id != $wpdb->blogid
@@ -214,7 +214,7 @@ class Webonary_Excel
 			else
 				$fields[] = trim($blog_details->blogname);
 
-			$fields[] = $wpdb->get_var("SELECT option_value FROM $wpdb->options WHERE option_name = 'countryName'");
+			$fields[] = get_option('countryName');
 
 			$fields[] = 'https://' . $domainPath;
 
@@ -264,13 +264,7 @@ class Webonary_Excel
 			$publishedDate = $wpdb->get_var( "SELECT DATE_FORMAT(link_updated, '%Y-%m-%d') AS link_updated FROM wp_links WHERE link_url LIKE '%" . $domainPath . "%'");
 			$fields[]      = $publishedDate;
 
-			$email = $wpdb->get_var("SELECT option_value FROM $wpdb->options WHERE option_name = 'admin_email'");
-
-			$fields[] = $email;
-
-			$notes = $wpdb->get_var("SELECT option_value FROM $wpdb->options WHERE option_name = 'notes'");
-
-			$fields[] = stripslashes($notes);
+			$fields[] = get_option('admin_email');
 
 			if (empty($lastEditDate))
 				$fields[] = '';
@@ -278,6 +272,8 @@ class Webonary_Excel
 				$fields[] = '';
 			else
 				$fields[] = $lastEditDate;
+
+			$fields[] = stripslashes(get_option('notes'));
 
 			$mapped = array_map(function($a) {
 
@@ -337,9 +333,9 @@ class Webonary_Excel
         <th>Create Date</th>
         <th>Publish Date</th>
         <th>Contact Email</th>
-        <th>Notes</th>
         <th>Last Upload</th>
-      </tr>
+        <th>Notes</th>
+	</tr>
     </thead>
     <tbody></tbody>
   </table>


### PR DESCRIPTION
1. Cache dictionary data in options table for persistence, and use it when dictionary data is requested
2. Renew cache when a dictionary is reset from the Cloud (e.g. dictionary is reloaded)

Also:
1. move Notes to the end of the display row
2. use get_option instead of db calls