### PR TITLE
Feature/issue 434

### DIFF
--- a/webonary-cloud-api/lambda/__tests__/methodAuthorize.test.ts
+++ b/webonary-cloud-api/lambda/__tests__/methodAuthorize.test.ts
@@ -55,7 +55,7 @@ describe('methodAuthorize', () => {
   });
 
   test('auth denied', async (): Promise<void> => {
-    mockedAxios.post.mockImplementation(() => Promise.resolve({ status: 200, data: 'some error' }));
+    mockedAxios.post.mockImplementation(() => Promise.resolve({ status: 401, data: 'some error' }));
 
     await lambdaHandler(event, context, (error, result) => {
       expect(error).toBe(null);
@@ -64,7 +64,7 @@ describe('methodAuthorize', () => {
       expect(result.policyDocument.Statement[0].Action).toBe('execute-api:Invoke');
     });
 
-    return expect.hasAssertions();
+    await expect.assertions(4);
   });
 
   test('auth error no headers', async (): Promise<void> => {
@@ -75,13 +75,9 @@ describe('methodAuthorize', () => {
       methodArn: '',
     };
 
-    try {
-      await lambdaHandler(emptyEvent, context, (error) => {
-        expect(error).toBe('Unauthorized');
-      });
-    } catch (error) {
-      console.log(error);
-    }
+    await lambdaHandler(emptyEvent, context, (error) => {
+      expect(error).toBe('Unauthorized');
+    });
 
     return expect.hasAssertions();
   });
@@ -89,13 +85,9 @@ describe('methodAuthorize', () => {
   test('auth error generic', async (): Promise<void> => {
     mockedAxios.post.mockImplementation(() => Promise.resolve({ status: 500, data: 'some error' }));
 
-    try {
-      await lambdaHandler(event, context, (error) => {
-        expect(error).toBe('Unauthorized');
-      });
-    } catch (error) {
-      console.log(error);
-    }
+    await lambdaHandler(event, context, (error) => {
+      expect(error).toBe('Unauthorized');
+    });
 
     return expect.hasAssertions();
   });
@@ -106,10 +98,8 @@ describe('methodAuthorize', () => {
       throw new Error(errorMessage);
     });
 
-    await lambdaHandler(event, context, (error, result) => {
-      expect(error).toBe(null);
-      expect(result.policyDocument.Statement.length === 1);
-      expect(result.policyDocument.Statement[0].Effect).toBe('Deny');
+    await lambdaHandler(event, context, (error) => {
+      expect(error).toBe('Unauthorized');
     });
 
     return expect.hasAssertions();

--- a/webonary-cloud-api/lambda/methodAuthorize.ts
+++ b/webonary-cloud-api/lambda/methodAuthorize.ts
@@ -1,5 +1,6 @@
 import { CustomAuthorizerEvent, APIGatewayAuthorizerResult, Context, Callback } from 'aws-lambda';
 import axios from 'axios';
+import { createHash } from 'crypto';
 
 import { getBasicAuthCredentials } from './utils';
 
@@ -27,6 +28,12 @@ function generatePolicy(
   return authResult;
 }
 
+function getPrincipalId(authorizationHeader: string): string {
+  const sha1 = createHash('sha1');
+  sha1.update(authorizationHeader);
+  return sha1.digest('hex');
+}
+
 export async function handler(
   event: CustomAuthorizerEvent,
   context: Context,
@@ -47,7 +54,7 @@ export async function handler(
   // eslint-disable-next-line no-console
   console.log(`Processing policy for ${credentials.username} to resource ${event.methodArn}`);
   // Same user should have the same access to post/delete dictionary entry data as well as files.
-  const principalId = credentials.username;
+  const principalId = getPrincipalId(authHeaders);
   const resourceRegex = /(POST\/post|DELETE\/delete)\/(dictionary|entry|file)\/(.+)$/i;
 
   async function getAuthPolicy() {

--- a/webonary-cloud-api/lambda/methodAuthorize.ts
+++ b/webonary-cloud-api/lambda/methodAuthorize.ts
@@ -75,7 +75,7 @@ export async function handler(
     const resources = [event.methodArn.replace(resourceRegex, `*/*/${dictionaryId}`)];
 
     // eslint-disable-next-line no-console
-    console.log(`Denying ${principalId} to access {resources}`);
+    console.log(`Denying ${principalId} to access ${resources}: ${error}`);
     return callback(null, generatePolicy(principalId, 'Deny', resources)); // 403
   }
 }

--- a/webonary-cloud-api/lambda/methodAuthorize.ts
+++ b/webonary-cloud-api/lambda/methodAuthorize.ts
@@ -1,4 +1,4 @@
-import { CustomAuthorizerEvent, APIGatewayAuthorizerResult, Context, Callback } from 'aws-lambda';
+import { APIGatewayAuthorizerResult, Callback, Context, CustomAuthorizerEvent } from 'aws-lambda';
 import axios from 'axios';
 import { createHash } from 'crypto';
 
@@ -11,7 +11,7 @@ function generatePolicy(
   effect: Effect,
   resources: string[],
 ): APIGatewayAuthorizerResult {
-  const authResult: APIGatewayAuthorizerResult = {
+  return {
     principalId,
     policyDocument: {
       Version: '2012-10-17',
@@ -24,8 +24,6 @@ function generatePolicy(
       ],
     },
   };
-
-  return authResult;
 }
 
 function getPrincipalId(authorizationHeader: string): string {

--- a/webonary-cloud-api/lambda/methodAuthorize.ts
+++ b/webonary-cloud-api/lambda/methodAuthorize.ts
@@ -38,46 +38,46 @@ export async function handler(
   const authHeaders = event.headers?.Authorization;
   const dictionaryId = event.pathParameters?.dictionaryId;
 
-  if (dictionaryId && authHeaders) {
-    const credentials = getBasicAuthCredentials(authHeaders);
-
-    // eslint-disable-next-line no-console
-    console.log(`Processing policy for ${credentials.username} to resource ${event.methodArn}`);
-    // Same user should have the same access to post/delete dictionary entry data as well as files.
-    const principalId = credentials.username;
-    const resourceRegex = /(POST\/post|DELETE\/delete)\/(dictionary|entry|file)\/(.+)$/i;
-
-    // Call Webonary.org for user authentication
-    axios.defaults.headers.post['Content-Type'] = 'application/json';
-    const authPath = `${process.env.WEBONARY_URL}/${dictionaryId}${process.env.WEBONARY_AUTH_PATH}`;
-
-    try {
-      const response = await axios.post(authPath, '{}', {
-        auth: credentials,
-      });
-
-      if (response.status === 200 && response.data) {
-        const resources = response.data.split(',').map((id: string) => {
-          // To allow for correct caching behavior, we use wildcards for method (POST or DELETE) and path. E.g.:
-          // arn:aws:execute-api:region:zz:zzz/prod/POST/post/dictionary/myDictionary will be replaced with
-          // arn:aws:execute-api:region:zz:zzz/prod/*/*/dictionary/myDictionary
-          return event.methodArn.replace(resourceRegex, `*/*/${id}`);
-        });
-
-        // eslint-disable-next-line no-console
-        console.log(`Creating policy for ${principalId} to access ${resources}`);
-        return callback(null, generatePolicy(principalId, 'Allow', resources));
-      }
-    } catch (error) {
-      const resources = [event.methodArn.replace(resourceRegex, `*/*/${dictionaryId}`)];
-
-      // eslint-disable-next-line no-console
-      console.log(`Denying ${principalId} to access {resources}`);
-      return callback(null, generatePolicy(principalId, 'Deny', resources)); // 403
-    }
+  if (!dictionaryId || !authHeaders) {
+    return callback('Unauthorized');
   }
 
-  return callback('Unauthorized');
+  const credentials = getBasicAuthCredentials(authHeaders);
+
+  // eslint-disable-next-line no-console
+  console.log(`Processing policy for ${credentials.username} to resource ${event.methodArn}`);
+  // Same user should have the same access to post/delete dictionary entry data as well as files.
+  const principalId = credentials.username;
+  const resourceRegex = /(POST\/post|DELETE\/delete)\/(dictionary|entry|file)\/(.+)$/i;
+
+  // Call Webonary.org for user authentication
+  axios.defaults.headers.post['Content-Type'] = 'application/json';
+  const authPath = `${process.env.WEBONARY_URL}/${dictionaryId}${process.env.WEBONARY_AUTH_PATH}`;
+
+  try {
+    const response = await axios.post(authPath, '{}', {
+      auth: credentials,
+    });
+
+    if (response.status === 200 && response.data) {
+      const resources = response.data.split(',').map((id: string) => {
+        // To allow for correct caching behavior, we use wildcards for method (POST or DELETE) and path. E.g.:
+        // arn:aws:execute-api:region:zz:zzz/prod/POST/post/dictionary/myDictionary will be replaced with
+        // arn:aws:execute-api:region:zz:zzz/prod/*/*/dictionary/myDictionary
+        return event.methodArn.replace(resourceRegex, `*/*/${id}`);
+      });
+
+      // eslint-disable-next-line no-console
+      console.log(`Creating policy for ${principalId} to access ${resources}`);
+      return callback(null, generatePolicy(principalId, 'Allow', resources));
+    }
+  } catch (error) {
+    const resources = [event.methodArn.replace(resourceRegex, `*/*/${dictionaryId}`)];
+
+    // eslint-disable-next-line no-console
+    console.log(`Denying ${principalId} to access {resources}`);
+    return callback(null, generatePolicy(principalId, 'Deny', resources)); // 403
+  }
 }
 
 export default handler;


### PR DESCRIPTION
Change authorization principalId so that it is a hash of the username and password. This should make AWS stop caching bad credentials.

Also clean up tests so hopefully it's clearer why tests are passing.

Fixes #434.