### PR TITLE
Normalize user supplied dictionaryIds to lowercase.

### DIFF
--- a/webonary-cloud-api/lambda/browseEntries.ts
+++ b/webonary-cloud-api/lambda/browseEntries.ts
@@ -46,7 +46,7 @@ export async function handler(
     // eslint-disable-next-line no-param-reassign
     context.callbackWaitsForEmptyEventLoop = false;
 
-    const dictionaryId = event.pathParameters?.dictionaryId;
+    const dictionaryId = event.pathParameters?.dictionaryId?.toLowerCase();
     const text = event.queryStringParameters?.text ?? '';
     const mainLang = event.queryStringParameters?.mainLang; // main language of the dictionary
     const lang = event.queryStringParameters?.lang ?? ''; // this is used to limit which language to search

--- a/webonary-cloud-api/lambda/deleteDictionary.ts
+++ b/webonary-cloud-api/lambda/deleteDictionary.ts
@@ -41,7 +41,7 @@ export async function handler(
   // eslint-disable-next-line no-param-reassign
   context.callbackWaitsForEmptyEventLoop = false;
 
-  const dictionaryId = event.pathParameters?.dictionaryId ?? '';
+  const dictionaryId = event.pathParameters?.dictionaryId?.toLowerCase();
   if (!dictionaryId) {
     return callback(null, Response.badRequest('Invalid parameters'));
   }

--- a/webonary-cloud-api/lambda/deleteEntry.ts
+++ b/webonary-cloud-api/lambda/deleteEntry.ts
@@ -38,7 +38,7 @@ export async function handler(
     // eslint-disable-next-line no-param-reassign
     context.callbackWaitsForEmptyEventLoop = false;
 
-    const dictionaryId = event.pathParameters?.dictionaryId;
+    const dictionaryId = event.pathParameters?.dictionaryId?.toLowerCase();
     const guid = event.queryStringParameters?.guid;
 
     const isReversalEntry = event.queryStringParameters?.entryType === ENTRY_TYPE_REVERSAL;

--- a/webonary-cloud-api/lambda/getDictionary.ts
+++ b/webonary-cloud-api/lambda/getDictionary.ts
@@ -72,7 +72,7 @@ export async function handler(
     // eslint-disable-next-line no-param-reassign
     context.callbackWaitsForEmptyEventLoop = false;
 
-    const dictionaryId = event.pathParameters?.dictionaryId;
+    const dictionaryId = event.pathParameters?.dictionaryId?.toLowerCase();
     const dbFind: DbFindParameters = { dictionaryId };
 
     dbClient = await connectToDB();

--- a/webonary-cloud-api/lambda/getEntry.ts
+++ b/webonary-cloud-api/lambda/getEntry.ts
@@ -35,7 +35,7 @@ export async function handler(
   // eslint-disable-next-line no-param-reassign
   context.callbackWaitsForEmptyEventLoop = false;
 
-  const dictionaryId = event.pathParameters?.dictionaryId;
+  const dictionaryId = event.pathParameters?.dictionaryId?.toLowerCase();
   const guid = event.queryStringParameters?.guid;
 
   const isReversalEntry = event.queryStringParameters?.entryType === ENTRY_TYPE_REVERSAL;

--- a/webonary-cloud-api/lambda/methodAuthorize.ts
+++ b/webonary-cloud-api/lambda/methodAuthorize.ts
@@ -36,7 +36,7 @@ export async function handler(
   context.callbackWaitsForEmptyEventLoop = false;
 
   const authHeaders = event.headers?.Authorization;
-  const dictionaryId = event.pathParameters?.dictionaryId;
+  const dictionaryId = event.pathParameters?.dictionaryId?.toLowerCase();
 
   if (dictionaryId && authHeaders) {
     const credentials = getBasicAuthCredentials(authHeaders);

--- a/webonary-cloud-api/lambda/postDictionary.ts
+++ b/webonary-cloud-api/lambda/postDictionary.ts
@@ -152,7 +152,7 @@ export async function handler(
   context.callbackWaitsForEmptyEventLoop = false;
 
   const authHeaders = event.headers?.Authorization;
-  const dictionaryId = event.pathParameters?.dictionaryId;
+  const dictionaryId = event.pathParameters?.dictionaryId?.toLowerCase();
   const eventBody = event.body;
   if (!dictionaryId || !authHeaders) {
     return callback(null, Response.badRequest('Invalid parameters'));

--- a/webonary-cloud-api/lambda/postEntry.ts
+++ b/webonary-cloud-api/lambda/postEntry.ts
@@ -308,7 +308,7 @@ export async function handler(
   context.callbackWaitsForEmptyEventLoop = false;
 
   const authHeaders = event.headers?.Authorization;
-  const dictionaryId = event.pathParameters?.dictionaryId;
+  const dictionaryId = event.pathParameters?.dictionaryId?.toLowerCase();
   const isReversalEntry = event.queryStringParameters?.entryType === ENTRY_TYPE_REVERSAL;
   const eventBody = event.body;
   if (!dictionaryId || !authHeaders) {

--- a/webonary-cloud-api/lambda/searchEntries.ts
+++ b/webonary-cloud-api/lambda/searchEntries.ts
@@ -222,7 +222,7 @@ export async function handler(
   // eslint-disable-next-line no-param-reassign
   context.callbackWaitsForEmptyEventLoop = false;
 
-  const dictionaryId = event.pathParameters?.dictionaryId;
+  const dictionaryId = event.pathParameters?.dictionaryId?.toLowerCase();
   const text = event.queryStringParameters?.text;
   const mainLang = event.queryStringParameters?.mainLang; // main language of the dictionary
   const lang = event.queryStringParameters?.lang; // this is used to limit which language to search


### PR DESCRIPTION
Users sometimes put in upper case letters for dictionaryIds. We expect them to be all lowercase. In every user endpoint, normalize it to lowercase. 

Fixes #438