### PR TITLE
Allow permission even when mixed case dictionary ID is specified in FLex

### DIFF
--- a/webonary-cloud-api/lambda/methodAuthorize.ts
+++ b/webonary-cloud-api/lambda/methodAuthorize.ts
@@ -1,5 +1,5 @@
 import { CustomAuthorizerEvent, APIGatewayAuthorizerResult, Context, Callback } from 'aws-lambda';
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 
 import { getBasicAuthCredentials } from './utils';
 
@@ -36,48 +36,71 @@ export async function handler(
   context.callbackWaitsForEmptyEventLoop = false;
 
   const authHeaders = event.headers?.Authorization;
-  const dictionaryId = event.pathParameters?.dictionaryId?.toLowerCase();
+  const dictionaryPath = event.pathParameters?.dictionaryId ?? '';
+  const dictionaryId = dictionaryPath.toLowerCase();
 
-  if (dictionaryId && authHeaders) {
-    const credentials = getBasicAuthCredentials(authHeaders);
-
-    // eslint-disable-next-line no-console
-    console.log(`Processing policy for ${credentials.username} to resource ${event.methodArn}`);
-    // Same user should have the same access to post/delete dictionary entry data as well as files.
-    const principalId = credentials.username;
-    const resourceRegex = /(POST\/post|DELETE\/delete)\/(dictionary|entry|file)\/(.+)$/i;
-
-    // Call Webonary.org for user authentication
-    axios.defaults.headers.post['Content-Type'] = 'application/json';
-    const authPath = `${process.env.WEBONARY_URL}/${dictionaryId}${process.env.WEBONARY_AUTH_PATH}`;
-
-    try {
-      const response = await axios.post(authPath, '{}', {
-        auth: credentials,
-      });
-
-      if (response.status === 200 && response.data) {
-        const resources = response.data.split(',').map((id: string) => {
-          // To allow for correct caching behavior, we use wildcards for method (POST or DELETE) and path. E.g.:
-          // arn:aws:execute-api:region:zz:zzz/prod/POST/post/dictionary/myDictionary will be replaced with
-          // arn:aws:execute-api:region:zz:zzz/prod/*/*/dictionary/myDictionary
-          return event.methodArn.replace(resourceRegex, `*/*/${id}`);
-        });
-
-        // eslint-disable-next-line no-console
-        console.log(`Creating policy for ${principalId} to access ${resources}`);
-        return callback(null, generatePolicy(principalId, 'Allow', resources));
-      }
-    } catch (error) {
-      const resources = [event.methodArn.replace(resourceRegex, `*/*/${dictionaryId}`)];
-
-      // eslint-disable-next-line no-console
-      console.log(`Denying ${principalId} to access {resources}`);
-      return callback(null, generatePolicy(principalId, 'Deny', resources)); // 403
-    }
+  if (!dictionaryId || !authHeaders) {
+    return callback('Unauthorized');
   }
 
-  return callback('Unauthorized');
+  const credentials = getBasicAuthCredentials(authHeaders);
+  // eslint-disable-next-line no-console
+  console.log(`Processing policy for ${credentials.username} to resource ${event.methodArn}`);
+
+  // Same user should have the same access to post/delete dictionary entry data as well as files.
+  const principalId = credentials.username;
+  const resourceRegex = /(POST\/post|DELETE\/delete)\/(dictionary|entry|file)\/(.+)$/i;
+
+  // Call Webonary.org for user authentication
+  axios.defaults.headers.post['Content-Type'] = 'application/json';
+  const authPath = `${process.env.WEBONARY_URL}/${dictionaryId}${process.env.WEBONARY_AUTH_PATH}`;
+
+  try {
+    const response = await axios.post(authPath, '{}', { auth: credentials });
+    // eslint-disable-next-line no-console
+    console.log(
+      `Received auth response for ${credentials.username}: ${response.status} ${response.data}`,
+    );
+
+    if (response.status !== 200 || !response.data) {
+      return callback('Unauthorized');
+    }
+
+    const allowedDictionaries = response.data.split(','); // will always lowercase
+    if (!allowedDictionaries.includes(dictionaryId)) {
+      return callback('Unauthorized');
+    }
+
+    if (dictionaryId !== dictionaryPath) {
+      // All dictionary ids should be lowercase.
+      // But if user entered differently in FLex, let it access under that path as well.
+      allowedDictionaries.push(dictionaryPath);
+    }
+
+    const resources = allowedDictionaries.map((id: string) => {
+      // To allow for correct caching behavior, we use wildcards for method (POST or DELETE) and path. E.g.:
+      // arn:aws:execute-api:region:zz:zzz/prod/POST/post/dictionary/myDictionary will be replaced with
+      // arn:aws:execute-api:region:zz:zzz/prod/*/*/myDictionary
+      return event.methodArn.replace(resourceRegex, `*/*/${id}`);
+    });
+
+    // eslint-disable-next-line no-console
+    console.log(`Creating policy for ${principalId} to access ${resources}`);
+    return callback(null, generatePolicy(principalId, 'Allow', resources));
+  } catch (error) {
+    const axiosError = error as AxiosError;
+    if (axiosError.response?.status === 401) {
+      const resources = [event.methodArn.replace(resourceRegex, `*/*/${dictionaryPath}`)];
+
+      // eslint-disable-next-line no-console
+      console.log(`Denying ${principalId} to access ${resources}: ${axiosError.response.data}`);
+      return callback(null, generatePolicy(principalId, 'Deny', resources)); // 403
+    }
+
+    // eslint-disable-next-line no-console
+    console.log(`Unknown error for ${principalId} to access ${dictionaryId}`, axiosError.response);
+    return callback('Unauthorized');
+  }
 }
 
 export default handler;

--- a/webonary-cloud-api/lambda/s3Authorize.ts
+++ b/webonary-cloud-api/lambda/s3Authorize.ts
@@ -107,7 +107,13 @@ export async function handler(
       return callback(null, Response.badRequest(errorMessage));
     }
 
-    const signedUrl = getSignedUrl(dictionaryBucket, action, objectId);
+    // Ensure that dictionaryId is lowercase
+    const [dictionaryId, ...fileName] = objectId.split('/');
+    const signedUrl = getSignedUrl(
+      dictionaryBucket,
+      action,
+      `${dictionaryId.toLocaleLowerCase()}/${fileName.join('/')}`,
+    );
 
     return callback(null, Response.success(signedUrl));
   } catch (error) {

--- a/webonary-cloud-api/package.json
+++ b/webonary-cloud-api/package.json
@@ -11,11 +11,11 @@
     "deploy": "npm run test && npm run cdk deploy",
     "deploy-local": "npm run env-cmd cdk synth --no-staging >| template.yaml && sam local start-api",
     "lint": "tsc --noEmit && eslint '*/**/*.ts' --fix",
-    "lint-dry-run": "npx tsc --noEmit && eslint '*/**/*.ts' --fix-dry-run",
+    "lint-dry-run": "tsc --noEmit && eslint '*/**/*.ts' --fix-dry-run",
     "migrate": "cd mongo_utils && env-cmd -f ../.env mongo-migrate",
     "post-legacy": "env-cmd ts-node -r tsconfig-paths/register tools/post-legacy.ts",
-    "test": "npm run build && jest --detectOpenHandles --runInBand --force-exit",
-    "test-coverage": "npm run build && jest --detectOpenHandles --runInBand --force-exit --collectCoverage",
+    "test": "tsc && jest --detectOpenHandles --runInBand --force-exit",
+    "test-coverage": "tsc && jest --detectOpenHandles --runInBand --force-exit --collectCoverage",
     "watch": "tsc -w"
   },
   "devDependencies": {

--- a/webonary-cloud-api/tools/flexXhtmlParser.ts
+++ b/webonary-cloud-api/tools/flexXhtmlParser.ts
@@ -7,6 +7,13 @@ export interface Options {
   entryClass: string;
 }
 
+interface ParseEntry extends Options {
+  guid: string;
+  letterHead: string;
+  sortIndex: number;
+  entryData: string;
+}
+
 export class FlexXhtmlParser {
   protected options: Options;
 
@@ -51,14 +58,14 @@ export class FlexXhtmlParser {
         const sortIndex = index * 100;
 
         entries.push(
-          FlexXhtmlParser.parseEntry(
-            this.options.dictionaryId,
-            this.options.entryClass,
+          FlexXhtmlParser.parseEntry({
+            dictionaryId: this.options.dictionaryId.toLowerCase(),
+            entryClass: this.options.entryClass,
             guid,
             letterHead,
             sortIndex,
             entryData,
-          ),
+          }),
         );
       }
     });
@@ -66,14 +73,14 @@ export class FlexXhtmlParser {
     return entries;
   }
 
-  public static parseEntry(
-    dictionaryId: string,
-    entryClass: string,
-    guid: string,
-    letterHead: string,
-    sortIndex: number,
-    entryData: string,
-  ): Entry {
+  public static parseEntry({
+    dictionaryId,
+    entryClass,
+    guid,
+    letterHead,
+    sortIndex,
+    entryData,
+  }: ParseEntry): Entry {
     // const $ = cheerio.load(entryData);
 
     // NOTE: guid field in Webonary and FLex actually includes the character 'g' at the beginning

--- a/webonary-cloud-api/tools/flexXhtmlParserMain.ts
+++ b/webonary-cloud-api/tools/flexXhtmlParserMain.ts
@@ -150,7 +150,7 @@ export class FlexXhtmlParserMain extends FlexXhtmlParser {
   }
 
   public getDictionaryData(): DictionaryItem | undefined {
-    const id = this.options.dictionaryId;
+    const id = this.options.dictionaryId.toLowerCase();
     const dictionary = new DictionaryItem(id);
 
     if (id && this.parsedDictionaryEntries.length) {

--- a/webonary-cloud-api/tools/post-legacy.ts
+++ b/webonary-cloud-api/tools/post-legacy.ts
@@ -147,7 +147,7 @@ async function postFile(
 ): Promise<AxiosResponse | undefined> {
   const path = `/post/file/${dictionaryId}`;
   const data = JSON.stringify({
-    objectId: `${dictionaryId}/${file}`,
+    objectId: `${dictionaryId.toLowerCase()}/${file}`,
     action: 'putObject',
   });
   const config: AxiosRequestConfig = { auth: credentials };


### PR DESCRIPTION
All Webonary dictionary site ids are lowercase. However, FLex does not enforce this. So when a user enters a mixed case dictionary id in FLEX, we should still allow them to access their dictionary.

To accomplish this, we have to modify `methodAuthorize` to allow add the mixed-case dictionary id as part of the authorized resource policy, as well as the lowercase id and any other dictionaries that the user has access to. 

CAVEAT:
- Due to the 5 minute (by default) caching of auth policy by API Gateway, if the user first requested access for a lowercase dictionary id, then they will only be allowed to use that. Any attempt to access via a mixed case id will be denied, during the duration of the caching.
- However, if the user first entered a mixed case id, then it, along with its lower case variant, will both be in the allowed policy So the user can access via the mixed case id in its path for the duration of caching.
