### PR TITLE
453 give correct count for reversal indexes when more than one index

### DIFF
--- a/webonary-cloud-api/lambda/__tests__/databaseSetup.ts
+++ b/webonary-cloud-api/lambda/__tests__/databaseSetup.ts
@@ -25,10 +25,10 @@ export function setupMongo(): void {
 
 let nextDictionaryNumber = 1;
 /** Inserts a new dictionary into the database and returns its dictionaryId. */
-export async function createDictionary(): Promise<string> {
+export async function createDictionary(data = '{}'): Promise<string> {
   const dictionaryId = `test-dictionary-${nextDictionaryNumber}`;
   nextDictionaryNumber += 1;
 
-  await upsertDictionary('{}', dictionaryId, 'test-user');
+  await upsertDictionary(data, dictionaryId, 'test-user');
   return dictionaryId;
 }

--- a/webonary-cloud-api/lambda/__tests__/getDictionary.test.ts
+++ b/webonary-cloud-api/lambda/__tests__/getDictionary.test.ts
@@ -1,0 +1,73 @@
+import { APIGatewayEvent } from 'aws-lambda';
+
+import { createDictionary, setupMongo } from './databaseSetup';
+import { Dictionary } from '../dictionary.model';
+import { upsertEntries } from '../postEntry';
+
+import { handler } from '../getDictionary';
+
+setupMongo();
+
+const testUsername = 'test-username';
+
+describe('get Dictionary', () => {
+  test('get dictionary entries derived data', async () => {
+    const guids = ['guid1', 'guid2'];
+    const senseLangs = ['senseLangA', 'senseLangB'];
+    const dictionaryId = await createDictionary('{ "mainLanguage": "mainLangA" }');
+
+    const posts = guids.map((guid) => {
+      return {
+        guid,
+        senses: [
+          {
+            definitionorgloss: senseLangs.map((lang) => {
+              return { lang, value: `sense-${lang}` };
+            }),
+          },
+        ],
+      };
+    });
+
+    await upsertEntries(posts, false, dictionaryId, testUsername);
+
+    const event: Partial<APIGatewayEvent> = {
+      pathParameters: { dictionaryId },
+    };
+    const results = await handler(event as APIGatewayEvent);
+    const dictionary = JSON.parse(results.body);
+    expect(dictionary.definitionOrGlossLangs).toStrictEqual(['senseLangA', 'senseLangB']);
+    expect(dictionary.mainLanguage.entriesCount).toBe(2);
+  });
+
+  test('get dictionary reversal entries derived data', async () => {
+    const guids = ['guid1', 'guid2'];
+    const reversalFormLangs = ['reversalLangA', 'reversalLangB'];
+    const dictionaryData: Partial<Dictionary> = {
+      reversalLanguages: reversalFormLangs.map((lang) => {
+        return { lang, title: `title-${lang}`, letters: ['a'], cssFiles: [''] };
+      }),
+    };
+
+    const dictionaryId = await createDictionary(JSON.stringify(dictionaryData));
+
+    const posts = guids.map((guid) => {
+      return {
+        guid,
+        reversalform: reversalFormLangs.map((lang) => {
+          return { lang, value: `value-${lang}` };
+        }),
+      };
+    });
+    posts.push({ guid: '3', reversalform: [{ lang: reversalFormLangs[0], value: 'value' }] });
+    await upsertEntries(posts, true, dictionaryId, testUsername);
+
+    const event: Partial<APIGatewayEvent> = {
+      pathParameters: { dictionaryId },
+    };
+    const results = await handler(event as APIGatewayEvent);
+    const dictionary = JSON.parse(results.body);
+    expect(dictionary.reversalLanguages[0].entriesCount).toBe(3);
+    expect(dictionary.reversalLanguages[1].entriesCount).toBe(2);
+  });
+});

--- a/webonary-cloud-api/lambda/__tests__/methodAuthorize.test.ts
+++ b/webonary-cloud-api/lambda/__tests__/methodAuthorize.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
-import { APIGatewayRequestAuthorizerEvent, APIGatewayAuthorizerResult } from 'aws-lambda';
-import axios, { AxiosError } from 'axios';
+import { APIGatewayRequestAuthorizerEvent } from 'aws-lambda';
+import axios from 'axios';
 import lambdaHandler from '../methodAuthorize';
 
 jest.mock('axios');

--- a/webonary-cloud-api/lambda/__tests__/methodAuthorize.test.ts
+++ b/webonary-cloud-api/lambda/__tests__/methodAuthorize.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { CustomAuthorizerEvent, Context } from 'aws-lambda';
+import { APIGatewayRequestAuthorizerEvent, APIGatewayAuthorizerResult } from 'aws-lambda';
 import axios, { AxiosError } from 'axios';
 import lambdaHandler from '../methodAuthorize';
 
@@ -13,26 +13,10 @@ const headers = { Authorization: `Basic ${base64Credentials}` };
 
 const dictionaryId = 'testDictionary';
 
-const event: CustomAuthorizerEvent = {
-  type: 'testEventType',
+const event: Partial<APIGatewayRequestAuthorizerEvent> = {
   methodArn: `arn:something-something/POST/post/entry/${dictionaryId}`,
   pathParameters: { dictionaryId },
   headers,
-};
-
-const context: Context = {
-  callbackWaitsForEmptyEventLoop: false,
-  functionName: '',
-  functionVersion: '',
-  invokedFunctionArn: '',
-  memoryLimitInMB: '',
-  awsRequestId: '',
-  logGroupName: '',
-  logStreamName: '',
-  getRemainingTimeInMillis: () => 0,
-  done: () => undefined,
-  fail: () => undefined,
-  succeed: () => undefined,
 };
 
 describe('methodAuthorize', () => {
@@ -43,39 +27,29 @@ describe('methodAuthorize', () => {
         data: `${dictionaryId.toLowerCase()},another-dictionary`,
       }),
     );
-    await lambdaHandler(event, context, (error, result) => {
-      expect(error).toBe(null);
-      expect(result.principalId).toEqual(username);
-      expect(result.policyDocument.Statement[0].Effect).toBe('Allow');
-      expect(result.policyDocument.Statement[0].Action).toBe('execute-api:Invoke');
-      expect(result.policyDocument.Statement[0].Resource).toStrictEqual([
+    const result = await lambdaHandler(event as APIGatewayRequestAuthorizerEvent);
+    expect(result.principalId).toEqual(username);
+    expect(result.policyDocument.Statement[0]).toStrictEqual({
+      Action: 'execute-api:Invoke',
+      Effect: 'Allow',
+      Resource: [
         `arn:something-something/*/*/${dictionaryId.toLowerCase()}`,
         'arn:something-something/*/*/another-dictionary',
         `arn:something-something/*/*/${dictionaryId}`,
-      ]);
+      ],
     });
-
-    return expect.hasAssertions();
   });
 
   test('auth denied invalid username or password', async (): Promise<void> => {
     mockedAxios.post.mockRejectedValueOnce({ response: { status: 401 } });
 
-    // mockedAxios.post.mockImplementation(() => {
-    //   throw new AxiosError('Invalid username or password', '401');
-    // });
-
-    await lambdaHandler(event, context, (error, result) => {
-      expect(error).toBe(null);
-      expect(result.principalId).toEqual(username);
-      expect(result.policyDocument.Statement[0].Action).toBe('execute-api:Invoke');
-      expect(result.policyDocument.Statement[0].Effect).toBe('Deny');
-      expect(result.policyDocument.Statement[0].Resource).toStrictEqual([
-        `arn:something-something/*/*/${dictionaryId}`,
-      ]);
+    const result = await lambdaHandler(event as APIGatewayRequestAuthorizerEvent);
+    expect(result.principalId).toEqual(username);
+    expect(result.policyDocument.Statement[0]).toStrictEqual({
+      Action: 'execute-api:Invoke',
+      Effect: 'Deny',
+      Resource: [`arn:something-something/*/*/${dictionaryId}`],
     });
-
-    return expect.hasAssertions();
   });
 
   test('auth denied for dictionary', async (): Promise<void> => {
@@ -83,36 +57,29 @@ describe('methodAuthorize', () => {
       Promise.resolve({ status: 200, data: 'another-dictionary' }),
     );
 
-    await lambdaHandler(event, context, (error) => {
-      expect(error).toBe('Unauthorized');
-    });
-
-    return expect.hasAssertions();
+    await expect(lambdaHandler(event as APIGatewayRequestAuthorizerEvent)).rejects.toThrow(
+      'Unauthorized',
+    );
   });
 
   test('auth error no headers', async (): Promise<void> => {
     mockedAxios.post.mockImplementation(() => Promise.resolve({}));
 
-    const emptyEvent: CustomAuthorizerEvent = {
-      type: '',
+    const emptyEvent: Partial<APIGatewayRequestAuthorizerEvent> = {
       methodArn: '',
     };
 
-    await lambdaHandler(emptyEvent, context, (error) => {
-      expect(error).toBe('Unauthorized');
-    });
-
-    return expect.hasAssertions();
+    await expect(lambdaHandler(emptyEvent as APIGatewayRequestAuthorizerEvent)).rejects.toThrow(
+      'Unauthorized',
+    );
   });
 
   test('auth error generic', async (): Promise<void> => {
     mockedAxios.post.mockImplementation(() => Promise.resolve({ status: 500, data: 'some error' }));
 
-    await lambdaHandler(event, context, (error) => {
-      expect(error).toBe('Unauthorized');
-    });
-
-    return expect.hasAssertions();
+    await expect(lambdaHandler(event as APIGatewayRequestAuthorizerEvent)).rejects.toThrow(
+      'Unauthorized',
+    );
   });
 
   test('auth throws an unknown error', async (): Promise<void> => {
@@ -121,10 +88,8 @@ describe('methodAuthorize', () => {
       throw new Error(errorMessage);
     });
 
-    await lambdaHandler(event, context, (error) => {
-      expect(error).toBe('Unauthorized');
-    });
-
-    return expect.hasAssertions();
+    await expect(lambdaHandler(event as APIGatewayRequestAuthorizerEvent)).rejects.toThrow(
+      'Unauthorized',
+    );
   });
 });

--- a/webonary-cloud-api/lambda/__tests__/searchEntries.test.ts
+++ b/webonary-cloud-api/lambda/__tests__/searchEntries.test.ts
@@ -1,8 +1,8 @@
-import { searchEntries, SearchEntriesArguments } from '../searchEntries';
+import { APIGatewayProxyResult } from 'aws-lambda';
 
+import { searchEntries, SearchEntriesArguments } from '../searchEntries';
 import { upsertEntries } from '../postEntry';
 import { createDictionary, setupMongo } from './databaseSetup';
-import { Response } from '../response';
 
 setupMongo();
 
@@ -22,7 +22,7 @@ const defaultArguments: SearchEntriesArguments = {
   text: 'test-text',
 };
 
-function parseGuids(response: Response): string[] {
+function parseGuids(response: APIGatewayProxyResult): string[] {
   return (
     JSON.parse(response.body)
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/webonary-cloud-api/lambda/browseEntries.ts
+++ b/webonary-cloud-api/lambda/browseEntries.ts
@@ -18,7 +18,7 @@
  * @apiError (404) NotFound There are no matching entries.
  */
 
-import { APIGatewayEvent, Context, Callback } from 'aws-lambda';
+import { APIGatewayEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { MongoClient } from 'mongodb';
 import { connectToDB } from './mongo';
 import {
@@ -32,143 +32,127 @@ import {
 } from './db';
 import { DbFindParameters } from './base.model';
 import { DictionaryEntry, DbPaths, ENTRY_TYPE_REVERSAL } from './entry.model';
-import { createFailureResponse, getDbSkip } from './utils';
+import { getDbSkip } from './utils';
 import * as Response from './response';
 
 let dbClient: MongoClient;
 
-export async function handler(
-  event: APIGatewayEvent,
-  context: Context,
-  callback: Callback,
-): Promise<void> {
-  try {
-    // eslint-disable-next-line no-param-reassign
-    context.callbackWaitsForEmptyEventLoop = false;
+export async function handler(event: APIGatewayEvent): Promise<APIGatewayProxyResult> {
+  const dictionaryId = event.pathParameters?.dictionaryId?.toLowerCase();
+  const text = event.queryStringParameters?.text ?? '';
+  const mainLang = event.queryStringParameters?.mainLang; // main language of the dictionary
+  const lang = event.queryStringParameters?.lang ?? ''; // this is used to limit which language to search
+  const isReversalEntry = event.queryStringParameters?.entryType === ENTRY_TYPE_REVERSAL;
 
-    const dictionaryId = event.pathParameters?.dictionaryId?.toLowerCase();
-    const text = event.queryStringParameters?.text ?? '';
-    const mainLang = event.queryStringParameters?.mainLang; // main language of the dictionary
-    const lang = event.queryStringParameters?.lang ?? ''; // this is used to limit which language to search
-    const isReversalEntry = event.queryStringParameters?.entryType === ENTRY_TYPE_REVERSAL;
+  const countTotalOnly = event.queryStringParameters?.countTotalOnly;
 
-    const countTotalOnly = event.queryStringParameters?.countTotalOnly;
+  const pageNumber = Math.max(Number(event.queryStringParameters?.pageNumber ?? '1'), 1);
+  const pageLimit = Math.min(
+    Math.max(Number(event.queryStringParameters?.pageLimit ?? DB_MAX_DOCUMENTS_PER_CALL), 1),
+    DB_MAX_DOCUMENTS_PER_CALL,
+  );
 
-    const pageNumber = Math.max(Number(event.queryStringParameters?.pageNumber ?? '1'), 1);
-    const pageLimit = Math.min(
-      Math.max(Number(event.queryStringParameters?.pageLimit ?? DB_MAX_DOCUMENTS_PER_CALL), 1),
-      DB_MAX_DOCUMENTS_PER_CALL,
-    );
+  if (text === '') {
+    return Response.badRequest('Browse head letter must be specified.');
+  }
 
-    if (text === '') {
-      return callback(null, Response.badRequest('Browse head letter must be specified.'));
+  let dbCollection = '';
+  let dbSort = {};
+  let dbLocale = DB_COLLATION_LOCALE_DEFAULT_FOR_INSENSITIVITY;
+  let entries: Document[];
+  let primarySearch = true;
+  const dbFind: DbFindParameters = { dictionaryId };
+  const dbSkip = getDbSkip(pageNumber, pageLimit);
+
+  if (isReversalEntry) {
+    if (lang === '') {
+      return Response.badRequest('Language must be specified for browsing reversal entries.');
     }
 
-    let dbCollection = '';
-    let dbSort = {};
-    let dbLocale = DB_COLLATION_LOCALE_DEFAULT_FOR_INSENSITIVITY;
-    let entries: Document[];
-    let primarySearch = true;
-    const dbFind: DbFindParameters = { dictionaryId };
-    const dbSkip = getDbSkip(pageNumber, pageLimit);
+    primarySearch = true;
+    dbCollection = DB_COLLECTION_REVERSAL_ENTRIES;
+    dbFind[DbPaths.ENTRY_REVERSAL_FORM_LANG] = lang;
+    if (DB_COLLATION_LOCALES.includes(lang)) {
+      dbLocale = lang;
+    }
 
-    if (isReversalEntry) {
-      if (lang === '') {
-        return callback(
-          null,
-          Response.badRequest('Language must be specified for browsing reversal entries.'),
-        );
-      }
-
-      primarySearch = true;
-      dbCollection = DB_COLLECTION_REVERSAL_ENTRIES;
-      dbFind[DbPaths.ENTRY_REVERSAL_FORM_LANG] = lang;
-      if (DB_COLLATION_LOCALES.includes(lang)) {
-        dbLocale = lang;
+    // TODO: Make sure to set default sort for entries to be on main headword browse letter and value
+    dbSort = { 'reversalForm.0.value': 1, 'reversalForm.1.value': 1 };
+  } else {
+    dbCollection = DB_COLLECTION_DICTIONARY_ENTRIES;
+    if (lang === '') {
+      if (mainLang && DB_COLLATION_LOCALES.includes(mainLang)) {
+        dbLocale = mainLang;
       }
 
       // TODO: Make sure to set default sort for entries to be on main headword browse letter and value
-      dbSort = { 'reversalForm.0.value': 1, 'reversalForm.1.value': 1 };
+      dbSort = { 'mainHeadWord.0.value': 1, 'mainHeadWord.1.value': 1 };
     } else {
-      dbCollection = DB_COLLECTION_DICTIONARY_ENTRIES;
-      if (lang === '') {
-        if (mainLang && DB_COLLATION_LOCALES.includes(mainLang)) {
-          dbLocale = mainLang;
-        }
+      // generate reversal entries based on searching via definitions
+      primarySearch = false;
 
-        // TODO: Make sure to set default sort for entries to be on main headword browse letter and value
-        dbSort = { 'mainHeadWord.0.value': 1, 'mainHeadWord.1.value': 1 };
-      } else {
-        // generate reversal entries based on searching via definitions
-        primarySearch = false;
-
-        // TODO: Include reversal language in sorting?
-        /*
+      // TODO: Include reversal language in sorting?
+      /*
         dbSortKey = DbPaths.ENTRY_MAIN_HEADWORD_VALUE;
         if (DB_COLLATION_LOCALES.includes(lang)) {
           dbLocale = lang;
         }
         */
-      }
     }
-
-    dbClient = await connectToDB();
-    const db = dbClient.db(MONGO_DB_NAME);
-
-    if (primarySearch) {
-      dbFind.letterHead = text;
-
-      if (countTotalOnly && countTotalOnly === '1') {
-        const count = await db.collection(dbCollection).countDocuments(dbFind);
-        return callback(null, Response.success({ count }));
-      }
-
-      entries = await db
-        .collection(dbCollection)
-        .find(dbFind)
-        .collation({ locale: dbLocale, strength: DB_COLLATION_STRENGTH_FOR_CASE_INSENSITIVITY })
-        .sort({ sortIndex: 1, ...dbSort })
-        .skip(dbSkip)
-        .limit(pageLimit)
-        .toArray();
-    } else {
-      dbFind.reversalLetterHeads = { lang, value: text };
-
-      const pipeline: object[] = [
-        { $match: dbFind },
-        { $unwind: `$${DbPaths.ENTRY_SENSES}` },
-        { $unwind: `$${DbPaths.ENTRY_DEFINITION}` },
-        { $match: { [DbPaths.ENTRY_DEFINITION_LANG]: lang } },
-      ];
-
-      if (countTotalOnly && countTotalOnly === '1') {
-        pipeline.push({ $count: 'count' });
-        const count =
-          (await db.collection(DB_COLLECTION_DICTIONARY_ENTRIES).aggregate(pipeline).next()) ?? '0';
-        return callback(null, Response.success(count));
-      }
-
-      pipeline.push({ $sort: { [DbPaths.ENTRY_DEFINITION_VALUE]: 1 } });
-      entries = await db
-        .collection<DictionaryEntry>(DB_COLLECTION_DICTIONARY_ENTRIES)
-        .aggregate(pipeline, {
-          collation: { locale: dbLocale, strength: DB_COLLATION_STRENGTH_FOR_CASE_INSENSITIVITY },
-        })
-        .skip(dbSkip)
-        .limit(pageLimit)
-        .toArray();
-    }
-
-    if (!entries.length) {
-      return callback(null, Response.notFound([{}]));
-    }
-
-    return callback(null, Response.success(entries));
-  } catch (error) {
-    // eslint-disable-next-line no-console
-    console.log(error);
-    return callback(null, createFailureResponse(error));
   }
+
+  dbClient = await connectToDB();
+  const db = dbClient.db(MONGO_DB_NAME);
+
+  if (primarySearch) {
+    dbFind.letterHead = text;
+
+    if (countTotalOnly && countTotalOnly === '1') {
+      const count = await db.collection(dbCollection).countDocuments(dbFind);
+      return Response.success({ count });
+    }
+
+    entries = await db
+      .collection(dbCollection)
+      .find(dbFind)
+      .collation({ locale: dbLocale, strength: DB_COLLATION_STRENGTH_FOR_CASE_INSENSITIVITY })
+      .sort({ sortIndex: 1, ...dbSort })
+      .skip(dbSkip)
+      .limit(pageLimit)
+      .toArray();
+  } else {
+    dbFind.reversalLetterHeads = { lang, value: text };
+
+    const pipeline: object[] = [
+      { $match: dbFind },
+      { $unwind: `$${DbPaths.ENTRY_SENSES}` },
+      { $unwind: `$${DbPaths.ENTRY_DEFINITION}` },
+      { $match: { [DbPaths.ENTRY_DEFINITION_LANG]: lang } },
+    ];
+
+    if (countTotalOnly && countTotalOnly === '1') {
+      pipeline.push({ $count: 'count' });
+      const count =
+        (await db.collection(DB_COLLECTION_DICTIONARY_ENTRIES).aggregate(pipeline).next()) ?? '0';
+      return Response.success(count);
+    }
+
+    pipeline.push({ $sort: { [DbPaths.ENTRY_DEFINITION_VALUE]: 1 } });
+    entries = await db
+      .collection<DictionaryEntry>(DB_COLLECTION_DICTIONARY_ENTRIES)
+      .aggregate(pipeline, {
+        collation: { locale: dbLocale, strength: DB_COLLATION_STRENGTH_FOR_CASE_INSENSITIVITY },
+      })
+      .skip(dbSkip)
+      .limit(pageLimit)
+      .toArray();
+  }
+
+  if (!entries.length) {
+    return Response.notFound();
+  }
+
+  return Response.success(entries);
 }
 
 export default handler;

--- a/webonary-cloud-api/lambda/deleteDictionary.ts
+++ b/webonary-cloud-api/lambda/deleteDictionary.ts
@@ -14,7 +14,7 @@
  * @apiUse BadRequest
  */
 
-import { APIGatewayEvent, Context, Callback } from 'aws-lambda';
+import { APIGatewayEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { MongoClient } from 'mongodb';
 import { connectToDB } from './mongo';
 import {
@@ -24,7 +24,6 @@ import {
   DB_COLLECTION_REVERSAL_ENTRIES,
 } from './db';
 import * as Response from './response';
-import { createFailureResponse } from './utils';
 
 let dbClient: MongoClient;
 
@@ -33,55 +32,42 @@ if (dictionaryBucket === '') {
   throw Error('S3 bucket not set');
 }
 
-export async function handler(
-  event: APIGatewayEvent,
-  context: Context,
-  callback: Callback,
-): Promise<void> {
-  // eslint-disable-next-line no-param-reassign
-  context.callbackWaitsForEmptyEventLoop = false;
-
+export async function handler(event: APIGatewayEvent): Promise<APIGatewayProxyResult> {
   const dictionaryId = event.pathParameters?.dictionaryId?.toLowerCase();
   if (!dictionaryId) {
-    return callback(null, Response.badRequest('Invalid parameters'));
+    return Response.badRequest('Invalid parameters');
   }
 
   dbClient = await connectToDB();
   const db = dbClient.db(MONGO_DB_NAME);
 
-  try {
-    // eslint-disable-next-line no-console
-    console.log(`Start deleting dictionary ${dictionaryId}`);
+  // eslint-disable-next-line no-console
+  console.log(`Start deleting dictionary ${dictionaryId}`);
 
-    const [dbResultDictionary, dbResultEntry, dbResultReversal] = await Promise.all([
-      db.collection(DB_COLLECTION_DICTIONARIES).deleteOne({ _id: dictionaryId }),
-      db.collection(DB_COLLECTION_DICTIONARY_ENTRIES).deleteMany({ dictionaryId }),
-      db.collection(DB_COLLECTION_REVERSAL_ENTRIES).deleteMany({ dictionaryId }),
-    ]);
+  const [dbResultDictionary, dbResultEntry, dbResultReversal] = await Promise.all([
+    db.collection(DB_COLLECTION_DICTIONARIES).deleteOne({ _id: dictionaryId }),
+    db.collection(DB_COLLECTION_DICTIONARY_ENTRIES).deleteMany({ dictionaryId }),
+    db.collection(DB_COLLECTION_REVERSAL_ENTRIES).deleteMany({ dictionaryId }),
+  ]);
 
-    /*
-     * NOTE: deleteDictionaryFolder can take longer than API Gateway max timeout, which is 30 seconds.
-     * This will result in 504 Gateway timeout, with message "Endpoint request timed out".
-     * There is no way to capture that in a Lambda function, which has a 120 second timeout.
-     * So we will not delete files, except via clean up script (TODO).
-     */
+  /*
+   * NOTE: deleteDictionaryFolder can take longer than API Gateway max timeout, which is 30 seconds.
+   * This will result in 504 Gateway timeout, with message "Endpoint request timed out".
+   * There is no way to capture that in a Lambda function, which has a 120 second timeout.
+   * So we will not delete files, except via clean up script (TODO).
+   */
 
-    // const deletedFilesCount = await deleteS3Folder(dictionaryBucket, dictionaryId);
+  // const deletedFilesCount = await deleteS3Folder(dictionaryBucket, dictionaryId);
 
-    const result = {
-      deleteDictionaryCount: dbResultDictionary.deletedCount,
-      deletedEntryCount: dbResultEntry.deletedCount,
-      deletedReversalCount: dbResultReversal.deletedCount,
-    };
+  const result = {
+    deleteDictionaryCount: dbResultDictionary.deletedCount,
+    deletedEntryCount: dbResultEntry.deletedCount,
+    deletedReversalCount: dbResultReversal.deletedCount,
+  };
 
-    // eslint-disable-next-line no-console
-    console.log(`Completed deleting dictionary ${dictionaryId}`);
-    return callback(null, Response.success(result));
-  } catch (error) {
-    // eslint-disable-next-line no-console
-    console.log(`ERROR: while deleting dictionary ${dictionaryId}`, error);
-    return callback(null, createFailureResponse(error));
-  }
+  // eslint-disable-next-line no-console
+  console.log(`Completed deleting dictionary ${dictionaryId}`);
+  return Response.success(result);
 }
 
 export default handler;

--- a/webonary-cloud-api/lambda/deleteEntry.ts
+++ b/webonary-cloud-api/lambda/deleteEntry.ts
@@ -15,7 +15,7 @@
  * @apiError (404) NotFound Cannot find the specified dictionary.
  */
 
-import { APIGatewayEvent, Context, Callback } from 'aws-lambda';
+import { APIGatewayEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { MongoClient, DeleteResult } from 'mongodb';
 import { connectToDB } from './mongo';
 import {
@@ -25,58 +25,41 @@ import {
 } from './db';
 import { ENTRY_TYPE_REVERSAL } from './entry.model';
 import * as Response from './response';
-import { createFailureResponse } from './utils';
 
 let dbClient: MongoClient;
 
-export async function handler(
-  event: APIGatewayEvent,
-  context: Context,
-  callback: Callback,
-): Promise<void> {
-  try {
-    // eslint-disable-next-line no-param-reassign
-    context.callbackWaitsForEmptyEventLoop = false;
+export async function handler(event: APIGatewayEvent): Promise<APIGatewayProxyResult> {
+  const dictionaryId = event.pathParameters?.dictionaryId?.toLowerCase();
+  const guid = event.queryStringParameters?.guid;
 
-    const dictionaryId = event.pathParameters?.dictionaryId?.toLowerCase();
-    const guid = event.queryStringParameters?.guid;
+  const isReversalEntry = event.queryStringParameters?.entryType === ENTRY_TYPE_REVERSAL;
 
-    const isReversalEntry = event.queryStringParameters?.entryType === ENTRY_TYPE_REVERSAL;
+  const dbCollection = isReversalEntry
+    ? DB_COLLECTION_REVERSAL_ENTRIES
+    : DB_COLLECTION_DICTIONARY_ENTRIES;
 
-    const dbCollection = isReversalEntry
-      ? DB_COLLECTION_REVERSAL_ENTRIES
-      : DB_COLLECTION_DICTIONARY_ENTRIES;
-
-    if (!guid || guid === '') {
-      return callback(null, Response.badRequest('guid must be specified.'));
-    }
-
-    dbClient = await connectToDB();
-    const db = dbClient.db(MONGO_DB_NAME);
-
-    const count = await db.collection(dbCollection).countDocuments({ guid, dictionaryId });
-
-    if (!count) {
-      return callback(null, Response.notFound({}));
-    }
-
-    const dbResultEntry: DeleteResult = await db
-      .collection(DB_COLLECTION_DICTIONARY_ENTRIES)
-      .deleteOne({ guid, dictionaryId });
-
-    // TODO: How to delete S3 files in the dictionary folder???
-
-    return callback(
-      null,
-      Response.success({
-        deletedEntryCount: dbResultEntry.deletedCount,
-      }),
-    );
-  } catch (error) {
-    // eslint-disable-next-line no-console
-    console.log(error);
-    return callback(null, createFailureResponse(error));
+  if (!guid || guid === '') {
+    return Response.badRequest('guid must be specified.');
   }
+
+  dbClient = await connectToDB();
+  const db = dbClient.db(MONGO_DB_NAME);
+
+  const count = await db.collection(dbCollection).countDocuments({ guid, dictionaryId });
+
+  if (!count) {
+    return Response.notFound();
+  }
+
+  const dbResultEntry: DeleteResult = await db
+    .collection(DB_COLLECTION_DICTIONARY_ENTRIES)
+    .deleteOne({ guid, dictionaryId });
+
+  // TODO: How to delete S3 files in the dictionary folder???
+
+  return Response.success({
+    deletedEntryCount: dbResultEntry.deletedCount,
+  });
 }
 
 export default handler;

--- a/webonary-cloud-api/lambda/getDictionary.ts
+++ b/webonary-cloud-api/lambda/getDictionary.ts
@@ -45,7 +45,7 @@
  * @apiError (404) NotFound Cannot find a dictionary with the supplied id.
  */
 
-import { APIGatewayEvent, Context, Callback } from 'aws-lambda';
+import { APIGatewayEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { MongoClient } from 'mongodb';
 import { connectToDB } from './mongo';
 import {
@@ -59,63 +59,50 @@ import { DbPaths } from './entry.model';
 
 import { DbFindParameters } from './base.model';
 import * as Response from './response';
-import { createFailureResponse } from './utils';
 
 let dbClient: MongoClient;
 
-export async function handler(
-  event: APIGatewayEvent,
-  context: Context,
-  callback: Callback,
-): Promise<void> {
-  try {
-    // eslint-disable-next-line no-param-reassign
-    context.callbackWaitsForEmptyEventLoop = false;
+export async function handler(event: APIGatewayEvent): Promise<APIGatewayProxyResult> {
+  const dictionaryId = event.pathParameters?.dictionaryId?.toLowerCase();
+  const dbFind: DbFindParameters = { dictionaryId };
 
-    const dictionaryId = event.pathParameters?.dictionaryId?.toLowerCase();
-    const dbFind: DbFindParameters = { dictionaryId };
+  dbClient = await connectToDB();
+  const db = dbClient.db(MONGO_DB_NAME);
+  const dbItem: Dictionary | null = await db
+    .collection<Dictionary>(DB_COLLECTION_DICTIONARIES)
+    .findOne({ _id: dictionaryId });
 
-    dbClient = await connectToDB();
-    const db = dbClient.db(MONGO_DB_NAME);
-    const dbItem: Dictionary | null = await db
-      .collection<Dictionary>(DB_COLLECTION_DICTIONARIES)
-      .findOne({ _id: dictionaryId });
-
-    if (!dbItem) {
-      return callback(null, Response.notFound({}));
-    }
-
-    // get unique language codes from definitionOrGloss
-    // TODO: Populate this during dictionary upload
-    dbItem.definitionOrGlossLangs = await db
-      .collection(DB_COLLECTION_DICTIONARY_ENTRIES)
-      .distinct(DbPaths.ENTRY_DEFINITION_LANG, dbFind);
-
-    // get total entries
-    // TODO: Populate this during dictionary upload
-    dbItem.mainLanguage.entriesCount = await db
-      .collection(DB_COLLECTION_DICTIONARY_ENTRIES)
-      .countDocuments(dbFind);
-
-    // get reversal entry counts
-    // TODO: Populate this during dictionary upload
-    const reversalEntriesCounts = await Promise.all(
-      dbItem.reversalLanguages.map(async ({ lang }) => {
-        dbFind[DbPaths.ENTRY_REVERSAL_FORM_LANG] = lang;
-        return db.collection(DB_COLLECTION_REVERSAL_ENTRIES).countDocuments(dbFind);
-      }),
-    );
-
-    reversalEntriesCounts.forEach((entriesCount, index) => {
-      dbItem.reversalLanguages[index].entriesCount = entriesCount;
-    });
-
-    return callback(null, Response.success(dbItem));
-  } catch (error) {
-    // eslint-disable-next-line no-console
-    console.log(error);
-    return callback(null, createFailureResponse(error));
+  if (!dbItem) {
+    return Response.notFound();
   }
+
+  // get unique language codes from definitionOrGloss
+  // TODO: Populate this during dictionary upload
+  dbItem.definitionOrGlossLangs = await db
+    .collection(DB_COLLECTION_DICTIONARY_ENTRIES)
+    .distinct(DbPaths.ENTRY_DEFINITION_LANG, dbFind);
+
+  // get total entries
+  // TODO: Populate this during dictionary upload
+  dbItem.mainLanguage.entriesCount = await db
+    .collection(DB_COLLECTION_DICTIONARY_ENTRIES)
+    .countDocuments(dbFind);
+
+  // get reversal entry counts
+  // TODO: Populate this during dictionary upload
+
+  const reversalEntriesCounts = await Promise.all(
+    dbItem.reversalLanguages.map(async ({ lang }) => {
+      dbFind[DbPaths.ENTRY_REVERSAL_FORM_LANG] = lang;
+      return db.collection(DB_COLLECTION_REVERSAL_ENTRIES).countDocuments(dbFind);
+    }),
+  );
+
+  reversalEntriesCounts.forEach((entriesCount, index) => {
+    dbItem.reversalLanguages[index].entriesCount = entriesCount;
+  });
+
+  return Response.success(dbItem);
 }
 
 export default handler;

--- a/webonary-cloud-api/lambda/getDictionary.ts
+++ b/webonary-cloud-api/lambda/getDictionary.ts
@@ -90,11 +90,12 @@ export async function handler(event: APIGatewayEvent): Promise<APIGatewayProxyRe
 
   // get reversal entry counts
   // TODO: Populate this during dictionary upload
-
   const reversalEntriesCounts = await Promise.all(
     dbItem.reversalLanguages.map(async ({ lang }) => {
-      dbFind[DbPaths.ENTRY_REVERSAL_FORM_LANG] = lang;
-      return db.collection(DB_COLLECTION_REVERSAL_ENTRIES).countDocuments(dbFind);
+      return db.collection(DB_COLLECTION_REVERSAL_ENTRIES).countDocuments({
+        ...dbFind,
+        [DbPaths.ENTRY_REVERSAL_FORM_LANG]: lang,
+      });
     }),
   );
 

--- a/webonary-cloud-api/lambda/response.ts
+++ b/webonary-cloud-api/lambda/response.ts
@@ -1,52 +1,64 @@
-export const BAD_REQUEST = 'BadRequest';
+import { APIGatewayProxyResult } from 'aws-lambda';
 
-type ResponseBody = string | object;
+export type ResponseBody = string | object | [object];
 
-export interface Response {
-  statusCode: number;
-  headers: object;
-  body: string;
+function buildError(statusCode: number, error: ResponseBody): APIGatewayProxyResult {
+  return buildResponse(statusCode, typeof error === 'string' ? { message: error } : error);
 }
 
-function buildResponse(statusCode: number, response: ResponseBody, header?: object): Response {
-  let headers = {
-    'Access-Control-Allow-Origin': '*',
-    'Access-Control-Allow-Credentials': true,
+function buildResponse(
+  statusCode: number,
+  responseBody: ResponseBody,
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  header?: object,
+): APIGatewayProxyResult {
+  const response: APIGatewayProxyResult = {
+    statusCode,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Credentials': true,
+    },
+    body: '',
   };
 
   if (header) {
-    headers = { ...headers, ...header };
+    response.headers = { ...response.headers, ...header };
   }
 
-  let body = response;
-  if (typeof response === 'string') {
-    const contentType = {
-      'Content-Type': 'text/plain',
-    };
-    headers = { ...headers, ...contentType };
+  if (typeof responseBody === 'string') {
+    response.headers = { ...response.headers, 'Content-Type': 'text/plain' };
+    response.body = responseBody;
   } else {
-    body = JSON.stringify(response);
+    response.body = JSON.stringify(responseBody);
   }
 
-  return { statusCode, headers, body: body as string };
+  return response;
 }
 
-export function success(body: ResponseBody): Response {
+export function success(body: ResponseBody): APIGatewayProxyResult {
   return buildResponse(200, body);
 }
 
-export function badRequest(body: ResponseBody): Response {
-  return buildResponse(400, { errorType: BAD_REQUEST, errorMessage: body });
-}
-
-export function failure(body: ResponseBody): Response {
-  return buildResponse(500, body);
-}
-
-export function notFound(body: ResponseBody): Response {
-  return buildResponse(404, body);
-}
-
-export function redirect(location: string): Response {
+export function redirect(location: string): APIGatewayProxyResult {
   return buildResponse(302, '', { Location: location });
+}
+
+export function badRequest(error = 'Bad request'): APIGatewayProxyResult {
+  return buildError(400, error);
+}
+
+export function unauthorized(error = 'Unauthorized'): APIGatewayProxyResult {
+  return buildError(401, error);
+}
+
+export function forbidden(error = 'Forbidden'): APIGatewayProxyResult {
+  return buildError(403, error);
+}
+
+export function notFound(error = 'Not found'): APIGatewayProxyResult {
+  return buildError(404, error);
+}
+
+export function failure(error = 'Internal Server Error'): APIGatewayProxyResult {
+  return buildError(500, error);
 }

--- a/webonary-cloud-api/lambda/utils.ts
+++ b/webonary-cloud-api/lambda/utils.ts
@@ -89,13 +89,6 @@ export function copyObjectIgnoreKeyCase(toObject: object, fromObject: object): o
   return copyObject;
 }
 
-export function createFailureResponse(error: any) {
-  if (error instanceof Error) {
-    return failure({ errorType: error.name, errorMessage: error.message });
-  }
-  return failure({ error });
-}
-
 export function setSearchableEntries(entries: ListOptionItem[]): ListOptionItem[] {
   return entries.map((entry) => {
     const newEntry = entry;


### PR DESCRIPTION
This fixes the bug that always returned same number of reversal entry count when there are more than one reversal languages for a dictionary.

Also, the older `callback()` style of return from Lambda invocations were replaced with newer, easier return of a response or a throw.