### PR TITLE
Data migration to collection per dictionary

### DIFF
--- a/webonary-cloud-api/lambda/dictionary.model.ts
+++ b/webonary-cloud-api/lambda/dictionary.model.ts
@@ -75,10 +75,3 @@ export class DictionaryItem implements Dictionary {
     this.semanticDomains = Array(new ListOptionItem());
   }
 }
-
-export enum DbPaths {
-  SEM_DOMS_LANG = 'semanticDomains.lang',
-  SEM_DOMS_ABBREV = 'semanticDomains.abbrev',
-  SEM_DOMS_VALUE = 'semanticDomains.value',
-  SEM_DOMS_VALUE_INSENSITIVE = 'semanticDomains.valueInsensitive',
-}

--- a/webonary-cloud-api/lambda/entry.model.ts
+++ b/webonary-cloud-api/lambda/entry.model.ts
@@ -1,4 +1,13 @@
 /* eslint-disable max-classes-per-file */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type EntryType = Record<string, any> & {
+  _id: string;
+  guid: string;
+  dictionaryId: string;
+  updatedAt?: Date;
+  updatedBy?: string;
+};
+
 export interface EntryFile {
   id: string;
   src: string;

--- a/webonary-cloud-api/lambda/getDictionary.ts
+++ b/webonary-cloud-api/lambda/getDictionary.ts
@@ -67,6 +67,9 @@ export async function handler(event: APIGatewayEvent): Promise<APIGatewayProxyRe
     return Response.badRequest('Dictionary must be in the path.');
   }
 
+  // eslint-disable-next-line no-console
+  console.log(`Getting dictionary ${dictionaryId}...`);
+
   dbClient = await connectToDB();
   const db = dbClient.db(MONGO_DB_NAME);
   const dbItem: Dictionary | null = await db
@@ -108,6 +111,9 @@ export async function handler(event: APIGatewayEvent): Promise<APIGatewayProxyRe
   reversalEntriesCounts.forEach((entriesCount, index) => {
     dbItem.reversalLanguages[index].entriesCount = entriesCount;
   });
+
+  // eslint-disable-next-line no-console
+  console.log(`Found ${dictionaryId}`, dbItem);
 
   return Response.success(dbItem);
 }

--- a/webonary-cloud-api/lambda/searchEntries.ts
+++ b/webonary-cloud-api/lambda/searchEntries.ts
@@ -169,7 +169,7 @@ export async function handler(event: APIGatewayEvent): Promise<APIGatewayProxyRe
   }
 
   // eslint-disable-next-line no-console
-  console.log(`Searching ${dbCollectionEntries(dictionaryId)}...`, dbFind);
+  console.log(`Searching ${dbCollectionEntries(dictionaryId)}: ${JSON.stringify(dbFind)}`);
 
   // STEP: 5: Return counts only or full search result
   if (countTotalOnly) {
@@ -181,8 +181,9 @@ export async function handler(event: APIGatewayEvent): Promise<APIGatewayProxyRe
   }
 
   const entries = await cursor.skip(getDbSkip(pageNumber, pageLimit)).limit(pageLimit).toArray();
+
   // eslint-disable-next-line no-console
-  console.log(`Found ${entries.length} entries`, entries[0]);
+  console.log(`Found ${entries.length} entries: ${JSON.stringify(entries[0])}`);
   return entries.length ? Response.success(entries) : Response.notFound();
 }
 

--- a/webonary-cloud-api/mongo_utils/migrations/Migration20230121T1720ZCollectionPerDictionary.ts
+++ b/webonary-cloud-api/mongo_utils/migrations/Migration20230121T1720ZCollectionPerDictionary.ts
@@ -28,13 +28,18 @@ export class Migration20230121T1720ZCollectionPerDictionary implements Migration
     // sequentially process to not overburden Mongo
     // eslint-disable-next-line no-restricted-syntax
     for (const dictionaryId of dictionaryIds) {
-      logMessage(`Started migrating dictionary ${dictionaryId}... `);
+      if (dictionaryId === 'orma') {
+        logMessage(`Started migrating dictionary ${dictionaryId}... `);
 
-      const resultCount = await this.migrateEntries(db, dictionaryId);
-      logMessage(`Completed migrating ${resultCount} dictionary ${dictionaryId} entries.`);
+        const resultCount = await this.migrateEntries(db, dictionaryId);
+        logMessage(`Completed migrating ${resultCount} dictionary ${dictionaryId} entries.`);
 
-      await createEntriesIndexes(db, dictionaryId);
-      logMessage(`Created indexes for ${dictionaryId} entries.`);
+        await createEntriesIndexes(db, dictionaryId);
+        logMessage(`Created indexes for ${dictionaryId} entries.`);
+
+        await db.collection(DB_COLLECTION_ENTRIES).deleteMany({ dictionaryId });
+        logMessage(`Deleted legacy ${dictionaryId} entries.`);
+      }
     }
   }
 

--- a/webonary-cloud-api/mongo_utils/migrations/Migration20230121T1720ZCollectionPerDictionary.ts
+++ b/webonary-cloud-api/mongo_utils/migrations/Migration20230121T1720ZCollectionPerDictionary.ts
@@ -1,0 +1,147 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable import/no-relative-packages */
+/* eslint-disable no-await-in-loop */
+/* eslint-disable no-console */
+import * as cheerio from 'cheerio';
+import { Db } from 'mongodb';
+import { MigrationInterface } from 'mongo-migrate-ts';
+
+// use relative path so mongo-migrate cli can find it
+import { DB_COLLECTION_ENTRIES, createEntriesIndexes, dbCollectionEntries } from '../../lambda/db';
+import { DbPaths } from '../../lambda/entry.model';
+import { transformToEntry } from '../../lambda/postEntry';
+
+const logMessage = (message: string, previousTime?: number): void => {
+  const currentTime = Date.now();
+  const inSeconds = previousTime
+    ? `in ${Math.floor((currentTime - previousTime) / 1000)} seconds`
+    : '';
+  console.log(`\n ${new Date(currentTime).toString()} ${message} ${inSeconds}`);
+};
+
+export class Migration20230121T1720ZCollectionPerDictionary implements MigrationInterface {
+  parser: cheerio.Root;
+
+  public async up(db: Db): Promise<any> {
+    const dictionaryIds = await this.getLegacyDictionaryIds(db);
+
+    // sequentially process to not overburden Mongo
+    // eslint-disable-next-line no-restricted-syntax
+    for (const dictionaryId of dictionaryIds) {
+      logMessage(`Started migrating dictionary ${dictionaryId}... `);
+
+      const resultCount = await this.migrateEntries(db, dictionaryId);
+      logMessage(`Completed migrating ${resultCount} dictionary ${dictionaryId} entries.`);
+
+      await createEntriesIndexes(db, dictionaryId);
+      logMessage(`Created indexes for ${dictionaryId} entries.`);
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public async down(db: Db): Promise<any> {
+    console.log('Nothing to undo here!');
+  }
+
+  async getLegacyDictionaryIds(db: Db): Promise<string[]> {
+    const legacyCollection = db.collection(DB_COLLECTION_ENTRIES);
+    return legacyCollection.distinct(DbPaths.DICTIONARY_ID);
+  }
+
+  async migrateEntries(db: Db, dictionaryId: string) {
+    const entriesCollection = dbCollectionEntries(dictionaryId);
+    const legacyEntries = await db
+      .collection(DB_COLLECTION_ENTRIES)
+      .find({ dictionaryId })
+      .toArray();
+
+    const resultPromises = legacyEntries.map(async (legacyEntry) => {
+      const migratedEntry = transformToEntry({ postedEntry: legacyEntry, dictionaryId });
+
+      // Step 1: Move renamed fields
+
+      if (migratedEntry.mainHeadWord) {
+        migratedEntry.mainheadword = migratedEntry.mainHeadWord;
+        delete migratedEntry.mainHeadWord;
+      }
+
+      if (migratedEntry.morphoSyntaxAnalysis) {
+        migratedEntry.morphosyntaxanalysis = {
+          partofspeech: migratedEntry.morphoSyntaxAnalysis.partOfSpeech,
+        };
+        delete migratedEntry.morphoSyntaxAnalysis;
+      }
+
+      if (migratedEntry.senses && migratedEntry.senses.length) {
+        migratedEntry.senses = migratedEntry.senses?.map(
+          ({
+            guid,
+            definitionOrGloss,
+            examplesContents,
+            semanticDomains,
+          }: {
+            guid?: string;
+            definitionOrGloss?: object[];
+            examplesContents?: object[];
+            semanticDomains?: object[];
+          }) => {
+            const migratedSense: Record<string, string | object[]> = {};
+            if (guid) {
+              migratedSense.guid = guid;
+            }
+            if (definitionOrGloss?.length) {
+              migratedSense.definitionorgloss = definitionOrGloss;
+            }
+            if (examplesContents?.length) {
+              migratedSense.examplescontents = examplesContents;
+            }
+            if (semanticDomains?.length) {
+              migratedSense.semanticdomains = semanticDomains;
+            }
+            return migratedSense;
+          },
+        );
+      }
+
+      // Step 2: Try to derive missing fields from displayXhtml
+      this.parser = cheerio.load(migratedEntry.displayXhtml);
+
+      // these can exist in addition to or in place of mainheadword
+      ['headword', 'citationform', 'lexemeform'].forEach((langClass) => {
+        if (migratedEntry.displayXhtml.includes(`class="${langClass}"`)) {
+          const langObject = this.getLangObjects(langClass);
+          if (langObject.length) {
+            migratedEntry[langClass] = langObject;
+          }
+        }
+      });
+
+      // some dictionaries use this instead of partofspeech
+      ['graminfoabbrev'].forEach((langClass) => {
+        if (migratedEntry.displayXhtml.includes(`class="${langClass}"`)) {
+          const langObject = this.getLangObjects(langClass);
+          if (langObject.length) {
+            migratedEntry.morphosyntaxanalysis[langClass] = langObject;
+          }
+        }
+      });
+
+      return db
+        .collection(entriesCollection)
+        .updateOne({ _id: migratedEntry._id }, { $set: { ...migratedEntry } }, { upsert: true });
+    });
+
+    await Promise.all(resultPromises);
+    return resultPromises.length;
+  }
+
+  getLangObjects = (langParentClass: string) => {
+    const langObjects: object[] = [];
+    this.parser(`span.${langParentClass} span[lang]`).each((index, elem) => {
+      const lang = this.parser(elem).attr('lang');
+      const value = this.parser(elem).text();
+      langObjects.push({ lang, value });
+    });
+    return langObjects;
+  };
+}


### PR DESCRIPTION
This PR adds a migration script to take existing dictionary entries in `webonaryEntries` document to a collection per dictionary. During the migration, some efforts are made to populate data that were missing in the previous entries document:
- language specific search text fields
- `headword`, `citationform`, and `lexemeform` fields
- `graminfoabbrev` as the alternate place to store parts of speech data

Also, some of the previously camel-cased field names are renamed to all lower case to match what FLex actually sends.

In addition, a couple of minor bugs that were discovered were fixed:
- ensure dictionaryId is set per entry (Webonary Wordpress expects it to get audio file URLs)
- better handling of word boundaries in non-Latin dictioanary whole word search
- 