### PR TITLE
Migration script to recreate entries indexes

### DIFF
--- a/webonary-cloud-api/lambda/__tests__/databaseSetup.ts
+++ b/webonary-cloud-api/lambda/__tests__/databaseSetup.ts
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import { connectToDB } from '../mongo';
-import { MONGO_DB_NAME, createIndexes } from '../db';
+import { MONGO_DB_NAME, createReversalsIndexes } from '../db';
 
 import { upsertDictionary } from '../postDictionary';
 
@@ -15,7 +15,7 @@ export function setupMongo(): void {
 
     const dbClient = await connectToDB();
     const db = dbClient.db(MONGO_DB_NAME);
-    await createIndexes(db);
+    await createReversalsIndexes(db);
   });
 
   afterAll(async () => {

--- a/webonary-cloud-api/mongo_utils/migrations/Migration20220706T1320ZCreateIndexes.ts
+++ b/webonary-cloud-api/mongo_utils/migrations/Migration20220706T1320ZCreateIndexes.ts
@@ -2,17 +2,17 @@ import { Db } from 'mongodb';
 import { MigrationInterface } from 'mongo-migrate-ts';
 
 /* eslint-disable-next-line */
-import { createIndexes, dropIndexes } from '../../lambda/db'; // use relative path so mongo-migrate cli can find it
+import { createReversalsIndexes, dropReversalsIndexes } from '../../lambda/db'; // use relative path so mongo-migrate cli can find it
 
 export class Migration20220706T1320ZCreateIndexes implements MigrationInterface {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public async up(db: Db): Promise<any> {
-    await dropIndexes(db);
-    await createIndexes(db);
+    await dropReversalsIndexes(db);
+    await createReversalsIndexes(db);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public async down(db: Db): Promise<any> {
-    await dropIndexes(db);
+    await dropReversalsIndexes(db);
   }
 }

--- a/webonary-cloud-api/mongo_utils/migrations/Migration20230126T0445ZRecreatedEntriesIndexes.ts
+++ b/webonary-cloud-api/mongo_utils/migrations/Migration20230126T0445ZRecreatedEntriesIndexes.ts
@@ -1,0 +1,39 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable import/no-relative-packages */
+/* eslint-disable no-await-in-loop */
+/* eslint-disable no-console */
+import { Db } from 'mongodb';
+import { MigrationInterface } from 'mongo-migrate-ts';
+
+// use relative path so mongo-migrate cli can find it
+import {
+  DB_COLLECTION_DICTIONARIES,
+  createEntriesIndexes,
+  dropEntriesIndexes,
+} from '../../lambda/db';
+
+export class Migration20230126T0445ZRecreatedEntriesIndexes implements MigrationInterface {
+  public async up(db: Db): Promise<any> {
+    const dictionaries = await db
+      .collection(DB_COLLECTION_DICTIONARIES)
+      .find({})
+      .sort({ _id: 1 })
+      .project({ _id: 1 })
+      .toArray();
+
+    // sequentially process to not overburden Mongo
+    // eslint-disable-next-line no-restricted-syntax
+    for (const { _id: dictionaryId } of dictionaries) {
+      console.log(`\nDropping indexes for dictionary ${dictionaryId} entries`);
+      await dropEntriesIndexes(db, dictionaryId);
+
+      console.log(`\nCreating indexes for dictionary ${dictionaryId} entries`);
+      await createEntriesIndexes(db, dictionaryId);
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public async down(db: Db): Promise<any> {
+    console.log('Nothing to undo here!');
+  }
+}


### PR DESCRIPTION
Also:
- better relevance weights
- removed unnecessary `await` before `return`
- create and drop indexes for reversals and entries
