### PR TITLE
replaceOne rather than updateOne for replacement

### DIFF
--- a/webonary-cloud-api/lambda/postDictionary.ts
+++ b/webonary-cloud-api/lambda/postDictionary.ts
@@ -105,7 +105,7 @@
 
 import axios from 'axios';
 import { APIGatewayEvent, APIGatewayProxyResult } from 'aws-lambda';
-import { MongoClient, UpdateResult } from 'mongodb';
+import { MongoClient } from 'mongodb';
 
 import { connectToDB } from './mongo';
 import { MONGO_DB_NAME, DB_COLLECTION_DICTIONARIES, createEntriesIndexes } from './db';
@@ -119,7 +119,7 @@ export async function upsertDictionary(
   eventBody: string | null,
   dictionaryId: string,
   username: string,
-): Promise<{ dbResult: UpdateResult; updatedAt: string }> {
+) {
   const updatedAt = new Date();
 
   const posted = JSON.parse(eventBody as string);
@@ -133,7 +133,7 @@ export async function upsertDictionary(
 
   const dbResult = await db
     .collection(DB_COLLECTION_DICTIONARIES)
-    .updateOne({ _id: dictionaryId }, { $set: dictionaryItem }, { upsert: true });
+    .replaceOne({ _id: dictionaryId }, dictionaryItem, { upsert: true });
 
   await createEntriesIndexes(db, dictionaryId);
 

--- a/webonary-cloud-api/mongo_utils/migrations/Migration20230121T1720ZCollectionPerDictionary.ts
+++ b/webonary-cloud-api/mongo_utils/migrations/Migration20230121T1720ZCollectionPerDictionary.ts
@@ -131,7 +131,7 @@ export class Migration20230121T1720ZCollectionPerDictionary implements Migration
 
       return db
         .collection(entriesCollection)
-        .updateOne({ _id: migratedEntry._id }, { $set: { ...migratedEntry } }, { upsert: true });
+        .replaceOne({ _id: migratedEntry._id }, migratedEntry, { upsert: true });
     });
 
     await Promise.all(resultPromises);


### PR DESCRIPTION
We had been using `updateOne`, which overwrites exiting fields, rather than `replaceOne` which completely replaces a document. Since same documents (dictionary or entry) can be uploaded with different fields, it is safest to do a complete replacement rather than a partial replacement.