### PR TITLE
exclude empty lang in definitionOrGloss lang array

### DIFF
--- a/webonary-cloud-api/lambda/getDictionary.ts
+++ b/webonary-cloud-api/lambda/getDictionary.ts
@@ -91,7 +91,7 @@ export async function handler(event: APIGatewayEvent): Promise<APIGatewayProxyRe
       DbPaths.ENTRY_GLOSS_LANG,
     ].map((key) => entriesCollection.distinct(key)),
   );
-  dbItem.definitionOrGlossLangs = [...new Set(senseLangs.flat(1))];
+  dbItem.definitionOrGlossLangs = [...new Set(senseLangs.flat(1))].filter((lang) => lang !== '');
 
   // get total entries
   dbItem.mainLanguage.entriesCount = await entriesCollection.countDocuments();


### PR DESCRIPTION
This is to accommodate legacy data. New FLex entries should always have lang populated.