### PR TITLE
display dictionary info for each cloud dictionary

### DIFF
--- a/wp-resources/plugins/sil-dictionary-webonary/webonary/Webonary_Cloud.php
+++ b/wp-resources/plugins/sil-dictionary-webonary/webonary/Webonary_Cloud.php
@@ -284,32 +284,36 @@ class Webonary_Cloud
 	}
 
 	/**
-	 * @param string|null $dictionaryId
+	 * @param string $dictionaryId
 	 * @return ICloudDictionary|stdClass|null
 	 */
-	public static function getDictionary(?string $dictionaryId = null): ICloudDictionary|stdClass|null
+	public static function getDictionaryById(string $dictionaryId): ICloudDictionary|stdClass|null
 	{
-		if (!is_null(self::$dictionary))
-			return self::$dictionary;
-
-		$dictionary = get_option('dictionary');
-		if (!empty($dictionary)) {
-			self::$dictionary = $dictionary;
+		$request = self::$doGetDictionary . '/' . $dictionaryId;
+		$response = self::remoteGetJson($request);
+		if (self::isValidDictionary($response)) {
+			update_option('dictionary', $response);
+			return $response;
 		}
-		else {
+		
+		return null;
+	}
 
-			if (empty($dictionaryId))
-				$dictionaryId = self::getBlogDictionaryId();
+	/**
+	 * @return ICloudDictionary|stdClass|null
+	 */
+	public static function getDictionary(): ICloudDictionary|stdClass|null
+	{
+			if (!is_null(self::$dictionary))
+				return self::$dictionary;
 
-			$request = self::$doGetDictionary . '/' . $dictionaryId;
-			$response = self::remoteGetJson($request);
-			if (self::isValidDictionary($response)) {
-				update_option('dictionary', $response);
-				self::$dictionary = $response;
+			$dictionary = get_option('dictionary');
+			if (empty($dictionary)) {
+				$dictionary = self::getDictionaryById(self::getBlogDictionaryId());
 			}
-		}
 
-		return self::$dictionary;
+			self::$dictionary = $dictionary;
+			return self::$dictionary;
 	}
 
 	public static function getTotalCount($doAction, $apiParams = array()): int
@@ -319,7 +323,7 @@ class Webonary_Cloud
 		$response = self::remoteGetJson($request, $apiParams);
 		return $response->count ?? 0;
 	}
-
+		
 	public static function getEntriesAsPosts($doAction, $apiParams = array()): array
 	{
 		$request = $doAction . '/' . self::getBlogDictionaryId();

--- a/wp-resources/plugins/sil-dictionary-webonary/webonary/Webonary_Excel.php
+++ b/wp-resources/plugins/sil-dictionary-webonary/webonary/Webonary_Excel.php
@@ -239,7 +239,8 @@ class Webonary_Excel
 			if (get_option('useCloudBackend')) {
 				$fields[] = 'Cloud';
 
-				$dictionary = Webonary_Cloud::getDictionary();
+                $dictionaryId = str_replace('/', '', $blog_details->path);
+                $dictionary = get_option('dictionary', null) ?? Webonary_Cloud::getDictionaryById($dictionaryId);
 				if (is_null($dictionary)) {
 					$numpost = '';
 					$lastEditDate = '';


### PR DESCRIPTION
Currently, display-all-sites page does not display cloud dictionary entry count and date updated correctly.
It relies on `Weronary_Class`, which caches dictionary data when it is loaded, but the script switches to each of the sites as it iterates over them, which leads to all the cloud data to appear as the original blog site that was present when the class was loaded.

A work around is to not reply on this class, but instead retrieve dictionary from the options table for each blog, or retrieve from the Cloud and set it as an option if it does not already exist.
