### PR TITLE
use regex when browsing letter heads

### DIFF
--- a/webonary-cloud-api/lambda/__tests__/browseEntries.test.ts
+++ b/webonary-cloud-api/lambda/__tests__/browseEntries.test.ts
@@ -1,6 +1,7 @@
 import { APIGatewayEvent } from 'aws-lambda';
 
-import { createDictionary, setupMongo, parseGuids } from './databaseSetup';
+import { createDictionary, setupMongo } from './databaseSetup';
+import { parseGuids } from './utils';
 
 import { handler } from '../browseEntries';
 import { ENTRY_TYPE_REVERSAL } from '../entry.model';

--- a/webonary-cloud-api/lambda/__tests__/browseEntries.test.ts
+++ b/webonary-cloud-api/lambda/__tests__/browseEntries.test.ts
@@ -1,0 +1,150 @@
+import { APIGatewayEvent } from 'aws-lambda';
+
+import { createDictionary, setupMongo, parseGuids } from './databaseSetup';
+
+import { handler } from '../browseEntries';
+import { ENTRY_TYPE_REVERSAL } from '../entry.model';
+import { upsertEntries } from '../postEntry';
+
+setupMongo();
+
+const lang = 'testLang';
+const matchingGuid = 'test-matching-guid';
+const testUsername = 'test-username';
+
+describe('browse reversal entries', () => {
+  let dictionaryId = '';
+  let event: Partial<APIGatewayEvent> = {};
+
+  const testEntries = ['a', 'b', 'B', 'ba'].map((letterHead, sortIndex) => {
+    return {
+      guid: `${matchingGuid}-${letterHead}`,
+      letterHead,
+      reversalform: [{ lang, value: `value${letterHead}` }],
+      sortIndex,
+    };
+  });
+
+  const letterHead = 'a'; // note this is different lang from above
+  testEntries.push({
+    guid: `${matchingGuid}-${letterHead}-anotherLang`,
+    letterHead,
+    reversalform: [{ lang: 'anotherLang', value: `value${letterHead}` }],
+    sortIndex: 2,
+  });
+
+  beforeEach(async () => {
+    dictionaryId = await createDictionary();
+    await upsertEntries(testEntries, true, dictionaryId, testUsername);
+
+    // This is the base event, which all tests can start with.
+    // By itself, it will do a full text search in the dictionary
+    event = {
+      pathParameters: { dictionaryId },
+      queryStringParameters: { entryType: ENTRY_TYPE_REVERSAL },
+    };
+  });
+
+  test('require browse letter in text query param', async () => {
+    const response = await handler(event as APIGatewayEvent);
+    expect(response.statusCode).toBe(400);
+  });
+
+  test('require lang in text query param', async () => {
+    event = {
+      ...event,
+      queryStringParameters: { ...event.queryStringParameters, text: 'a' },
+    };
+    const response = await handler(event as APIGatewayEvent);
+    expect(response.statusCode).toBe(400);
+  });
+
+  test('match letter head', async () => {
+    const text = 'a';
+    event = {
+      ...event,
+      queryStringParameters: { ...event.queryStringParameters, lang, text },
+    };
+    const response = await handler(event as APIGatewayEvent);
+    expect(response.statusCode).toBe(200);
+    expect(parseGuids(response)).toEqual([`${matchingGuid}-${text}`]);
+  });
+
+  test('match letter head different case', async () => {
+    const text = 'A';
+    event = {
+      ...event,
+      queryStringParameters: { ...event.queryStringParameters, lang, text },
+    };
+    const response = await handler(event as APIGatewayEvent);
+    expect(response.statusCode).toBe(200);
+    expect(parseGuids(response)).toEqual([`${matchingGuid}-${text.toLocaleLowerCase()}`]);
+  });
+
+  test('match letter head case insensitive', async () => {
+    const text = 'b';
+    event = {
+      ...event,
+      queryStringParameters: { ...event.queryStringParameters, lang, text },
+    };
+    const response = await handler(event as APIGatewayEvent);
+    expect(response.statusCode).toBe(200);
+    expect(parseGuids(response)).toEqual([
+      `${matchingGuid}-${text}`,
+      `${matchingGuid}-${text.toLocaleUpperCase()}`,
+    ]);
+  });
+
+  test('matches and returns count', async () => {
+    const text = 'b';
+    event = {
+      ...event,
+      queryStringParameters: { ...event.queryStringParameters, lang, text, countTotalOnly: '1' },
+    };
+
+    const response = await handler(event as APIGatewayEvent);
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body).count).toEqual(2);
+  });
+});
+
+describe('browse dictionary entries', () => {
+  let dictionaryId = '';
+  let event: Partial<APIGatewayEvent> = {};
+
+  const testEntries = ['a', 'b', 'B', 'ba'].map((letterHead, sortIndex) => {
+    return {
+      guid: `${matchingGuid}-${letterHead}`,
+      letterHead,
+      sortIndex,
+    };
+  });
+
+  beforeEach(async () => {
+    dictionaryId = await createDictionary();
+    await upsertEntries(testEntries, false, dictionaryId, testUsername);
+
+    // This is the base event, which all tests can start with.
+    // By itself, it will do a full text search in the dictionary
+    event = { pathParameters: { dictionaryId } };
+  });
+
+  test('require browse letter in text query param', async () => {
+    const response = await handler(event as APIGatewayEvent);
+    expect(response.statusCode).toBe(400);
+  });
+
+  test('matches and return in correct sort order', async () => {
+    const text = 'b';
+    event = {
+      ...event,
+      queryStringParameters: { ...event.queryStringParameters, text },
+    };
+    const response = await handler(event as APIGatewayEvent);
+    expect(response.statusCode).toBe(200);
+    expect(parseGuids(response)).toEqual([
+      `${matchingGuid}-${text}`,
+      `${matchingGuid}-${text.toLocaleUpperCase()}`,
+    ]);
+  });
+});

--- a/webonary-cloud-api/lambda/__tests__/databaseSetup.ts
+++ b/webonary-cloud-api/lambda/__tests__/databaseSetup.ts
@@ -1,9 +1,8 @@
-// 'mongodb-memory-server' is' there in devDependencies. Not sure why it's not working.
-// eslint-disable-next-line import/no-extraneous-dependencies
+import { APIGatewayProxyResult } from 'aws-lambda';
 import { MongoMemoryServer } from 'mongodb-memory-server';
-import { connectToDB } from '../mongo';
-import { MONGO_DB_NAME, createReversalsIndexes } from '../db';
 
+import { MONGO_DB_NAME, createReversalsIndexes } from '../db';
+import { connectToDB } from '../mongo';
 import { upsertDictionary } from '../postDictionary';
 
 export function setupMongo(): void {
@@ -31,4 +30,13 @@ export async function createDictionary(data = '{}'): Promise<string> {
 
   await upsertDictionary(data, dictionaryId, 'test-user');
   return dictionaryId;
+}
+
+export function parseGuids(response: APIGatewayProxyResult): string[] {
+  return (
+    JSON.parse(response.body)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .map((entry: any) => entry.guid)
+      .filter((guid: string) => guid)
+  );
 }

--- a/webonary-cloud-api/lambda/__tests__/databaseSetup.ts
+++ b/webonary-cloud-api/lambda/__tests__/databaseSetup.ts
@@ -31,12 +31,3 @@ export async function createDictionary(data = '{}'): Promise<string> {
   await upsertDictionary(data, dictionaryId, 'test-user');
   return dictionaryId;
 }
-
-export function parseGuids(response: APIGatewayProxyResult): string[] {
-  return (
-    JSON.parse(response.body)
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .map((entry: any) => entry.guid)
-      .filter((guid: string) => guid)
-  );
-}

--- a/webonary-cloud-api/lambda/__tests__/searchEntries.test.ts
+++ b/webonary-cloud-api/lambda/__tests__/searchEntries.test.ts
@@ -1,6 +1,7 @@
 import { APIGatewayEvent } from 'aws-lambda';
 
-import { createDictionary, setupMongo, parseGuids } from './databaseSetup';
+import { createDictionary, setupMongo } from './databaseSetup';
+import { parseGuids } from './utils';
 
 import { upsertEntries } from '../postEntry';
 import { handler } from '../searchEntries';

--- a/webonary-cloud-api/lambda/__tests__/searchEntries.test.ts
+++ b/webonary-cloud-api/lambda/__tests__/searchEntries.test.ts
@@ -1,23 +1,15 @@
-import { APIGatewayEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { APIGatewayEvent } from 'aws-lambda';
 
-import { handler } from '../searchEntries';
+import { createDictionary, setupMongo, parseGuids } from './databaseSetup';
+
 import { upsertEntries } from '../postEntry';
-import { createDictionary, setupMongo } from './databaseSetup';
+import { handler } from '../searchEntries';
 import { removeDiacritics } from '../utils';
 
 setupMongo();
 
 const testUsername = 'test-username';
 const text = 'têstFullTextWôrd';
-
-function parseGuids(response: APIGatewayProxyResult): string[] {
-  return (
-    JSON.parse(response.body)
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .map((entry: any) => entry.guid)
-      .filter((guid: string) => guid)
-  );
-}
 
 describe('searchEntries params', () => {
   test('empty dictionary returns 404', async () => {

--- a/webonary-cloud-api/lambda/__tests__/utils.ts
+++ b/webonary-cloud-api/lambda/__tests__/utils.ts
@@ -1,0 +1,10 @@
+import { APIGatewayProxyResult } from 'aws-lambda';
+
+export function parseGuids(response: APIGatewayProxyResult): string[] {
+  return (
+    JSON.parse(response.body)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .map((entry: any) => entry.guid)
+      .filter((guid: string) => guid)
+  );
+}


### PR DESCRIPTION
Previously, we were using locale based case insensitive searching when browsing via letter heads.
This worked, but it was bypassing index on the letter head. We cannot build a locale specific index because for reversals, there are too many languages possible.

Instead, we now do a case insensitive regex search, to limit the number of reads.

Also, removed dead code for generating reversals from entries, and added tests for browsing via letter heads.

