### PR TITLE
Issue 78 parts of speech count

### DIFF
--- a/webonary-cloud-api/lambda/dictionary.model.ts
+++ b/webonary-cloud-api/lambda/dictionary.model.ts
@@ -23,6 +23,7 @@ export interface ListOption {
   name: string;
   nameInsensitive?: string; // lowercase and normalized
   guid?: string;
+  entriesCount?: number;
 }
 
 export class ListOptionItem implements ListOption {

--- a/webonary-cloud-api/lambda/entry.model.ts
+++ b/webonary-cloud-api/lambda/entry.model.ts
@@ -246,8 +246,6 @@ export enum DbPaths {
   ENTRY_GRAM_INFO_ABBREV_LANG = 'morphosyntaxanalysis.graminfoabbrev.lang',
   ENTRY_GRAM_INFO_ABBREV_VALUE = 'morphosyntaxanalysis.graminfoabbrev.value',
 
-  ENTRY_PLURAL_VALUE = 'morphosyntaxanalysis.partofspeech.value',
-
   ENTRY_LANG_TEXTS = 'langTexts',
   ENTRY_LANG_UNACCENTED_TEXTS = 'langUnaccentedTexts',
   ENTRY_SEARCH_TEXTS = 'searchTexts',

--- a/webonary-cloud-api/lambda/getDictionary.ts
+++ b/webonary-cloud-api/lambda/getDictionary.ts
@@ -113,7 +113,7 @@ export async function handler(event: APIGatewayEvent): Promise<APIGatewayProxyRe
         // de-dup
         (part, index, self) =>
           index ===
-          self.findIndex((p) => (p.lang === part.lang && p.abbreviation) === part.abbreviation),
+          self.findIndex((p) => p.lang === part.lang && p.abbreviation === part.abbreviation),
       )
       ?.map((part) => {
         // For some reason, FLex sends these decomposed, but entries are composed (e.g. for accented chars)

--- a/webonary-cloud-api/lambda/getDictionary.ts
+++ b/webonary-cloud-api/lambda/getDictionary.ts
@@ -20,7 +20,7 @@
  * @apiSuccess {String} partsOfSpeech.abbreviation Abbreviation of this part of speech
  * @apiSuccess {String} partsOfSpeech.name Name of this part of speech
  * @apiSuccess {String} partsOfSpeech.guid
- * @apiSuccess {String} partsOfSpeech.count Number of entries having this part of speech
+ * @apiSuccess {String} partsOfSpeech.entriesCount Number of entries having this part of speech
  *
  * @apiSuccess {Object[]} reversalLanguages Reversal languages defined for the main language
  * @apiSuccess {String} reversalLanguages.lang ISO language code

--- a/webonary-cloud-api/lambda/postEntry.ts
+++ b/webonary-cloud-api/lambda/postEntry.ts
@@ -214,7 +214,7 @@
 
 import { APIGatewayEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { load } from 'cheerio';
-import { MongoClient, UpdateResult } from 'mongodb';
+import { MongoClient } from 'mongodb';
 
 import { connectToDB } from './mongo';
 import {

--- a/wp-resources/plugins/sil-dictionary-webonary/webonary/Webonary_Cloud.php
+++ b/wp-resources/plugins/sil-dictionary-webonary/webonary/Webonary_Cloud.php
@@ -724,9 +724,10 @@ class Webonary_Cloud
 		if (!self::isValidDictionary($dictionary))
 			return [];
 
-		self::$parts_of_speech = array_filter($dictionary->partsOfSpeech, function($val) {
-			return !empty($val->abbreviation);
-		});
+		foreach ($dictionary->partsOfSpeech as $part) {
+			$part->name = $part->name . '&ensp;(' . $part->entriesCount . ')';
+			self::$parts_of_speech[] = $part;
+		}
 
 		return self::$parts_of_speech;
 	}


### PR DESCRIPTION
Display number of dictionary entries for a particular parts of speech in the search dropdown.
Note that the count is for all the languages, and does not change when a language is selected.

While working on this, the following were also fixed:
1.  For some reason, some of the accented characters in the parts of speech in the dictionary were decomposed, while the part of speech in entries were composed. The result was that the part of speech selected did not work. This is now fixed by composing parts of speech always in the dictionary fields.
2. The parts of speech dropdown sometimes displayed duplicates. This is now fixed by deduping the fields in the dictionary when sent back from the cloud.

<img width="369" alt="Screen Shot 2023-03-30 at 1 58 39 AM" src="https://user-images.githubusercontent.com/60716623/228769585-672c79a3-6791-48e5-9d97-9e486bcb1c80.png">
