### PR TITLE
check if parts of speech contains null values

### DIFF
--- a/webonary-cloud-api/lambda/getDictionary.ts
+++ b/webonary-cloud-api/lambda/getDictionary.ts
@@ -110,6 +110,10 @@ export async function handler(event: APIGatewayEvent): Promise<APIGatewayProxyRe
   dbItem.partsOfSpeech =
     dbItem.partsOfSpeech
       ?.filter(
+        // remove nulls
+        (part) => part.lang && part.abbreviation,
+      )
+      ?.filter(
         // de-dup
         (part, index, self) =>
           index ===


### PR DESCRIPTION
`getDictionary` sometimes fails because parts of speech abbreviation can sometimes contain `null` values from FLex. We need to filter these out before normalizing them.