### PR TITLE
Issue-533: disable `DisplaySubentriesAsMainEntries` option for cloud sites

### DIFF
--- a/wp-resources/plugins/sil-dictionary-webonary/include/configuration.php
+++ b/wp-resources/plugins/sil-dictionary-webonary/include/configuration.php
@@ -565,8 +565,12 @@ function webonary_conf_widget($showTitle = false)
 				<div style="margin:1rem 0">
 					<?php
 					$DisplaySubentriesAsMainEntries = get_option('DisplaySubentriesAsMainEntries');
-					if($DisplaySubentriesAsMainEntries == 1)
+					if ($DisplaySubentriesAsMainEntries == 1)
 					{
+						if (IS_CLOUD_BACKEND) {
+							update_option('DisplaySubentriesAsMainEntries', 0);
+						}
+						else {
 					?>
 					<input name="DisplaySubentriesAsMainEntries" type="checkbox" value="1"
 						<?php checked('1', $DisplaySubentriesAsMainEntries); ?> />
@@ -574,6 +578,7 @@ function webonary_conf_widget($showTitle = false)
 				</div>
 				<div style="margin:1rem 0">
 					<?php
+					    }
 					}
 					if(count($arrLanguageCodes) == 0)
 					{


### PR DESCRIPTION
I'm assuming the option was added for a reason, so I'm leaving it for the old sites.

Resolves #533 