### PR TITLE
allow searching with out search text specified

### DIFF
--- a/webonary-cloud-api/lambda/__tests__/searchEntries.test.ts
+++ b/webonary-cloud-api/lambda/__tests__/searchEntries.test.ts
@@ -56,6 +56,15 @@ describe('searchEntries search', () => {
     };
   });
 
+  test('no search params', async () => {
+    event = {
+      ...event,
+      queryStringParameters: { ...event.queryStringParameters, text: '' },
+    };
+    const response = await handler(event as APIGatewayEvent);
+    expect(response.statusCode).toBe(400);
+  });
+
   test('matches word in displayXhtml', async () => {
     // Use base event without modification
     const response = await handler(event as APIGatewayEvent);
@@ -179,6 +188,17 @@ describe('searchEntries search', () => {
     expect(parseGuids(response)).toEqual([matchingGuid]);
   });
 
+  test('matches part of speech with no search text', async () => {
+    event = {
+      ...event,
+      queryStringParameters: { lang, text: '' },
+      multiValueQueryStringParameters: { partOfSpeech: [partOfSpeech, `${partOfSpeech}Not`] },
+    };
+    const response = await handler(event as APIGatewayEvent);
+    expect(response.statusCode).toBe(200);
+    expect(parseGuids(response)).toEqual([matchingGuid]);
+  });
+
   test('matches part of speech using shared gram info', async () => {
     const sharedGramGuid = `${matchingGuid}-part-shared`;
     const sharedGramEntry = {
@@ -268,6 +288,17 @@ describe('searchEntries search', () => {
     event = {
       ...event,
       queryStringParameters: { lang, text, semanticDomain },
+      multiValueQueryStringParameters: { partOfSpeech: [partOfSpeech] },
+    };
+    const response = await handler(event as APIGatewayEvent);
+    expect(response.statusCode).toBe(200);
+    expect(parseGuids(response)).toEqual([matchingGuid]);
+  });
+
+  test('matches part of speech and semantic domain with no search text', async () => {
+    event = {
+      ...event,
+      queryStringParameters: { lang, text: '', semanticDomain },
       multiValueQueryStringParameters: { partOfSpeech: [partOfSpeech] },
     };
     const response = await handler(event as APIGatewayEvent);

--- a/webonary-cloud-api/lambda/searchEntries.ts
+++ b/webonary-cloud-api/lambda/searchEntries.ts
@@ -49,10 +49,8 @@ export async function handler(event: APIGatewayEvent): Promise<APIGatewayProxyRe
     return Response.badRequest('Dictionary must be in the path.');
   }
 
-  let text = event.queryStringParameters?.text?.trim();
-  if (!text) {
-    return Response.badRequest('Search text must be specified.');
-  }
+  // Search text may or may not be specified
+  let text = event.queryStringParameters?.text?.trim() ?? '';
   text = decodeURIComponent(text.replace(/\+/g, ' '));
 
   // `lang` is used to limit which language to search. Webonary will always send this.
@@ -79,10 +77,14 @@ export async function handler(event: APIGatewayEvent): Promise<APIGatewayProxyRe
     DB_MAX_DOCUMENTS_PER_CALL,
   );
 
+  // STEP 1: Validate input parameters
+  if (!text && !searchSemDoms && !partOfSpeech && !semanticDomain) {
+    return Response.badRequest('Search parameter must be specified.');
+  }
+
+  // STEP 2: Set main filters
   const dbClient: MongoClient = await connectToDB();
   const dbCollection = dbClient.db(MONGO_DB_NAME).collection(dbCollectionEntries(dictionaryId));
-
-  // STEP 1: Set main filters
   let dbFind: DbFindParameters = {};
   if (partOfSpeech && partOfSpeech.length > 0) {
     // decode since spaces can exist in part of speech
@@ -104,7 +106,7 @@ export async function handler(event: APIGatewayEvent): Promise<APIGatewayProxyRe
     dbFind[DbPaths.ENTRY_SEM_DOMS_ABBREV_VALUE] = semanticDomainAbbrevRegex(semanticDomain);
   }
 
-  // STEP 2: Set language condition
+  // STEP 3: Set language condition
   let langTextsPath;
   if (matchAccents) {
     langTextsPath = DbPaths.ENTRY_LANG_TEXTS;
@@ -113,9 +115,11 @@ export async function handler(event: APIGatewayEvent): Promise<APIGatewayProxyRe
     text = removeDiacritics(text);
   }
 
-  // STEP 3: Conduct main search (semantic domain, partial search, or fulltext search)
+  // STEP 4: Conduct main search (semantic domain, partial search, or fulltext search)
   let cursor;
-  if (searchSemDoms) {
+  if (!text) {
+    cursor = dbCollection.find(dbFind);
+  } else if (searchSemDoms) {
     if (semDomAbbrev && semDomAbbrev !== '') {
       dbFind[DbPaths.ENTRY_SEM_DOMS_ABBREV_VALUE] = semanticDomainAbbrevRegex(semDomAbbrev);
     } else {

--- a/wp-resources/plugins/sil-dictionary-webonary/webonary/Webonary_Cloud.php
+++ b/wp-resources/plugins/sil-dictionary-webonary/webonary/Webonary_Cloud.php
@@ -584,42 +584,18 @@ class Webonary_Cloud
 
 		// get the selected parts of speech list
 		$taxonomies = Webonary_Parts_Of_Speech::GetPartsOfSpeechSelected();
+	
+		$key = filter_input(INPUT_GET, 'key', FILTER_UNSAFE_RAW, array('options' => array('default' => '')));
 
-		if ($searchText === '' && !empty($taxonomies[0])) {
-
-			// This is a listing by semantic domains
-			$apiParams = array(
-				'text' => $taxonomies[0],
-				'searchSemDoms' => '1'
-			);
-
-		}
-		elseif ($searchText === '' && !empty($semantic_domains) && !empty(get_page_by_path('/browse/categories'))) {
-
-			// redirect to the semantic domains page
-			$url_lang = get_query_var('lang');
-			$sem_domain_number = $semantic_domains[0];
-			$sem_domain = Webonary_SemanticDomains::GetDomainName($sem_domain_number, self::getCurrentLanguage());
-			$url = get_site_url() . '/browse/categories/?semdomain=' . urlencode($sem_domain) . '&semnumber=' . $sem_domain_number . '.&lang=en';
-			if ($url_lang != '')
-				$url .= '&lang=' . $url_lang;
-
-			wp_redirect($url, 302, 'Webonary');
-			exit();
-		}
-		else {
-			$key = filter_input(INPUT_GET, 'key', FILTER_UNSAFE_RAW, array('options' => array('default' => '')));
-
-			$apiParams = [
-				'text' => $searchText,
-				'lang' => $key,
-				'partOfSpeech' => $taxonomies,
-				'semanticDomain' => $semantic_domains,
-				'matchPartial' => $search_cookie->match_whole_word ? '' : '1',  // note reverse logic, b/c params are opposite
-				'matchAccents' => $search_cookie->match_accents ? '1' : ''
-			];
-		}
-
+		$apiParams = [
+			'text' => $searchText,
+			'lang' => $key,
+			'partOfSpeech' => $taxonomies,
+			'semanticDomain' => $semantic_domains,
+			'matchPartial' => $search_cookie->match_whole_word ? '' : '1',  // note reverse logic, b/c params are opposite
+			'matchAccents' => $search_cookie->match_accents ? '1' : ''
+		];
+	
 		if (!isset($apiParams))
 			return null;
 


### PR DESCRIPTION
This resolves a part of  https://github.com/sillsdev/webonary/issues/546

When a user does a search without specifying a search text, but has specified either part of speech or semantic domain, then a search will be performed accordingly. If no parameters are specified, error 400 will be issued.
